### PR TITLE
ci: add GitHub Actions workflow for DMG releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release DMG
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Build release binary
+        run: swift build -c release
+
+      - name: Create app bundle and DMG
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          APP_NAME="MacGuard"
+          BUNDLE_ID="com.shenglong.macguard"
+          BUILD_DIR=".build/release"
+          DIST_DIR="dist"
+          APP_BUNDLE="$DIST_DIR/$APP_NAME.app"
+          DMG_NAME="$APP_NAME-$VERSION.dmg"
+
+          # Create app bundle structure
+          mkdir -p "$APP_BUNDLE/Contents/MacOS"
+          mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+          # Copy binary
+          cp "$BUILD_DIR/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
+
+          # Copy resources
+          if [ -d "$BUILD_DIR/${APP_NAME}_${APP_NAME}.bundle/Contents/Resources" ]; then
+              cp -R "$BUILD_DIR/${APP_NAME}_${APP_NAME}.bundle/Contents/Resources/"* "$APP_BUNDLE/Contents/Resources/"
+          fi
+
+          # Create Info.plist
+          cat > "$APP_BUNDLE/Contents/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>CFBundleDevelopmentRegion</key>
+              <string>en</string>
+              <key>CFBundleExecutable</key>
+              <string>$APP_NAME</string>
+              <key>CFBundleIconFile</key>
+              <string>AppIcon</string>
+              <key>CFBundleIdentifier</key>
+              <string>$BUNDLE_ID</string>
+              <key>CFBundleInfoDictionaryVersion</key>
+              <string>6.0</string>
+              <key>CFBundleName</key>
+              <string>$APP_NAME</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+              <key>CFBundleShortVersionString</key>
+              <string>$VERSION</string>
+              <key>CFBundleVersion</key>
+              <string>1</string>
+              <key>LSMinimumSystemVersion</key>
+              <string>13.0</string>
+              <key>LSUIElement</key>
+              <true/>
+              <key>NSBluetoothAlwaysUsageDescription</key>
+              <string>MacGuard uses Bluetooth to detect your trusted devices for auto-disarm.</string>
+              <key>NSHighResolutionCapable</key>
+              <true/>
+              <key>NSPrincipalClass</key>
+              <string>NSApplication</string>
+          </dict>
+          </plist>
+          PLIST
+
+          # Create app icon
+          if [ -f "Resources/AppIcon.png" ]; then
+              ICONSET="$DIST_DIR/AppIcon.iconset"
+              mkdir -p "$ICONSET"
+              sips -z 16 16 Resources/AppIcon.png --out "$ICONSET/icon_16x16.png"
+              sips -z 32 32 Resources/AppIcon.png --out "$ICONSET/icon_16x16@2x.png"
+              sips -z 32 32 Resources/AppIcon.png --out "$ICONSET/icon_32x32.png"
+              sips -z 64 64 Resources/AppIcon.png --out "$ICONSET/icon_32x32@2x.png"
+              sips -z 128 128 Resources/AppIcon.png --out "$ICONSET/icon_128x128.png"
+              sips -z 256 256 Resources/AppIcon.png --out "$ICONSET/icon_128x128@2x.png"
+              sips -z 256 256 Resources/AppIcon.png --out "$ICONSET/icon_256x256.png"
+              sips -z 512 512 Resources/AppIcon.png --out "$ICONSET/icon_256x256@2x.png"
+              sips -z 512 512 Resources/AppIcon.png --out "$ICONSET/icon_512x512.png"
+              sips -z 1024 1024 Resources/AppIcon.png --out "$ICONSET/icon_512x512@2x.png"
+              iconutil -c icns "$ICONSET" -o "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
+              rm -rf "$ICONSET"
+          fi
+
+          # Create DMG
+          DMG_TEMP="$DIST_DIR/dmg-temp"
+          mkdir -p "$DMG_TEMP"
+          cp -R "$APP_BUNDLE" "$DMG_TEMP/"
+          ln -s /Applications "$DMG_TEMP/Applications"
+          hdiutil create -volname "$APP_NAME" -srcfolder "$DMG_TEMP" -ov -format UDZO "$DIST_DIR/$DMG_NAME"
+          rm -rf "$DMG_TEMP"
+
+          echo "DMG_PATH=$DIST_DIR/$DMG_NAME" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.DMG_PATH }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automate DMG releases
- Triggers on version tags (e.g., `v1.2.0`)
- Builds app with Swift Package Manager
- Creates DMG with app bundle
- Uploads DMG to GitHub Release with auto-generated release notes

## Usage
To release a new version:
```bash
git tag v1.2.0
git push origin v1.2.0
```

## Test plan
- [ ] Merge this PR
- [ ] Create and push a test tag
- [ ] Verify workflow runs and creates release