### PR TITLE
feat(sparkle): add Sparkle 2.x auto-update framework

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -18,12 +18,28 @@
     <key>NSSupportsAutomaticTermination</key>
     <false/>
 
+    <!-- Sparkle Update Configuration -->
+    <key>SUFeedURL</key>
+    <string>https://raw.githubusercontent.com/shenglong209/MacGuard/main/appcast.xml</string>
+
+    <key>SUPublicEDKey</key>
+    <string>I7s26R56gqkm2GqhPOLdjcyK4YGcuEbSWsRBTEumlb8=</string>
+
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+
+    <key>SUScheduledCheckInterval</key>
+    <integer>86400</integer>
+
+    <key>SUShowReleaseNotes</key>
+    <true/>
+
     <!-- Version info -->
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
 
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>1.2.0</string>
 
     <key>CFBundleIdentifier</key>
     <string>com.shenglong.macguard</string>

--- a/Package.swift
+++ b/Package.swift
@@ -14,15 +14,26 @@ let package = Package(
             targets: ["MacGuard"]
         )
     ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0")
+    ],
     targets: [
         .executableTarget(
             name: "MacGuard",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             path: ".",
             exclude: [
                 "Info.plist",
                 "MacGuard.entitlements",
                 "Package.swift",
-                "README.md"
+                "README.md",
+                "plans",
+                "scripts",
+                "appcast.xml",
+                "dist",
+                "featured-image.png"
             ],
             sources: [
                 "MacGuardApp.swift",

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -245,7 +245,7 @@ struct SettingsView: View {
 
                 // About Section
                 Section {
-                    LabeledContent("Version", value: "1.1.0")
+                    LabeledContent("Version", value: "1.2.0")
                     LabeledContent("macOS", value: "13.0+ (Ventura)")
                     Link(destination: URL(string: "https://github.com/shenglong209/MacGuard")!) {
                         HStack {

--- a/plans/251218-1519-sparkle-auto-update/phase-01-spm-integration.md
+++ b/plans/251218-1519-sparkle-auto-update/phase-01-spm-integration.md
@@ -1,0 +1,151 @@
+# Phase 1: SPM Integration & Key Setup
+
+## Tasks
+
+### 1.1 Add Sparkle Dependency to Package.swift
+
+**File:** `Package.swift`
+
+```swift
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MacGuard",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(
+            name: "MacGuard",
+            targets: ["MacGuard"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "MacGuard",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
+            path: ".",
+            exclude: [
+                "Info.plist",
+                "MacGuard.entitlements",
+                "Package.swift",
+                "README.md",
+                "plans",
+                "scripts",
+                "appcast.xml"
+            ],
+            sources: [
+                "MacGuardApp.swift",
+                "Managers",
+                "Views",
+                "Models"
+            ],
+            resources: [
+                .copy("Resources")
+            ]
+        )
+    ]
+)
+```
+
+**Changes:**
+- Added `dependencies` array with Sparkle package
+- Added Sparkle to target dependencies
+- Added `plans`, `scripts`, `appcast.xml` to exclude list
+
+### 1.2 Verify Build
+
+```bash
+cd /Users/shenglong/DATA/XProject/MacGuard
+swift build
+```
+
+Expected: Build succeeds with Sparkle framework linked.
+
+### 1.3 Generate EdDSA Keypair
+
+```bash
+# Locate Sparkle tools after build
+SPARKLE_BIN=".build/artifacts/sparkle/Sparkle/bin"
+
+# Generate keypair (one-time operation)
+$SPARKLE_BIN/generate_keys
+
+# Output shows:
+# - Private key stored in Keychain (Access: com.apple.sparkle.private-key.ed25519)
+# - Public key (base64 string to copy)
+```
+
+**IMPORTANT:**
+- Copy the public key immediately
+- Export private key to secure backup: `$SPARKLE_BIN/generate_keys -x sparkle-private-key.txt`
+- Store backup in password manager or secure vault
+- **Never commit private key to repo**
+
+### 1.4 Update Info.plist with Sparkle Config
+
+**File:** `Info.plist`
+
+Add these keys:
+
+```xml
+<!-- Sparkle Update Configuration -->
+<key>SUFeedURL</key>
+<string>https://raw.githubusercontent.com/shenglong209/MacGuard/main/appcast.xml</string>
+
+<key>SUPublicEDKey</key>
+<string>YOUR_BASE64_PUBLIC_KEY_HERE</string>
+
+<!-- Enable automatic update checks -->
+<key>SUEnableAutomaticChecks</key>
+<true/>
+
+<!-- Check interval: 24 hours (default) -->
+<key>SUScheduledCheckInterval</key>
+<integer>86400</integer>
+
+<!-- Show release notes -->
+<key>SUShowReleaseNotes</key>
+<true/>
+```
+
+### 1.5 Update CFBundleVersion for Sparkle Compatibility
+
+Sparkle requires incrementing integer `CFBundleVersion` for each release.
+
+Current: `<string>1</string>`
+
+For v1.2.0 release, update to: `<string>2</string>`
+
+**Version Convention:**
+- `CFBundleVersion`: Integer (1, 2, 3...) - used by Sparkle for comparison
+- `CFBundleShortVersionString`: Semantic (1.0.0, 1.1.0...) - user-facing
+
+## Verification Checklist
+
+- [x] Package.swift updated with Sparkle dependency
+- [x] `swift build` succeeds (warning about appcast.xml expected)
+- [x] EdDSA keypair generated
+- [x] Public key added to Info.plist (format valid)
+- [x] Private key backed up securely (~/.macguard-keys/)
+- [x] SUFeedURL points to correct appcast location
+- [x] CFBundleVersion strategy documented and implemented
+
+**Phase Completed:** 2025-12-18 15:44
+
+**Code Review:** ✅ Passed - See `plans/reports/code-reviewer-251218-1540-phase-01-review.md`
+- 0 critical issues
+- 1 warning (expected appcast.xml absence)
+- 2 suggestions (verify keypair origin, update plan with actual excludes)
+
+## Notes
+
+- Sparkle 2.x requires macOS 10.13+, MacGuard requires 13.0+ - compatible
+- First update check happens on 2nd app launch (not first)
+- LSUIElement=true apps work with Sparkle - dialogs appear as floating windows

--- a/plans/251218-1519-sparkle-auto-update/phase-02-app-integration.md
+++ b/plans/251218-1519-sparkle-auto-update/phase-02-app-integration.md
@@ -1,0 +1,180 @@
+# Phase 2: App Code Integration
+
+## Tasks
+
+### 2.1 Create UpdateManager
+
+**New File:** `Managers/UpdateManager.swift`
+
+```swift
+// UpdateManager.swift
+// MacGuard - Anti-Theft Alarm for macOS
+
+import SwiftUI
+import Sparkle
+
+/// Manages Sparkle auto-update functionality
+final class UpdateManager: ObservableObject {
+    /// Shared instance for app-wide access
+    static let shared = UpdateManager()
+
+    /// Sparkle updater controller
+    private let updaterController: SPUStandardUpdaterController
+
+    /// Whether update check is available (not already in progress)
+    @Published var canCheckForUpdates = false
+
+    private init() {
+        // Initialize updater - starts automatic checking
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+
+        // Bind canCheckForUpdates to updater state
+        updaterController.updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+
+    /// Trigger manual update check (user-initiated)
+    func checkForUpdates() {
+        updaterController.checkForUpdates(nil)
+    }
+
+    /// Access to underlying updater for advanced usage
+    var updater: SPUUpdater {
+        updaterController.updater
+    }
+}
+```
+
+### 2.2 Initialize UpdateManager in MacGuardApp
+
+**File:** `MacGuardApp.swift`
+
+```swift
+// MacGuardApp.swift
+// MacGuard - Anti-Theft Alarm for macOS
+
+import SwiftUI
+
+@main
+struct MacGuardApp: App {
+    @StateObject private var alarmManager = AlarmStateManager()
+
+    // Initialize update manager (starts Sparkle)
+    private let updateManager = UpdateManager.shared
+
+    var body: some Scene {
+        MenuBarExtra {
+            MenuBarView()
+                .environmentObject(alarmManager)
+        } label: {
+            MenuBarIconView(state: alarmManager.state)
+        }
+        .menuBarExtraStyle(.window)
+    }
+}
+
+// ... rest of file unchanged
+```
+
+**Changes:**
+- Added `import Sparkle` is not needed here (UpdateManager handles it)
+- Added `updateManager` property to ensure initialization on app launch
+
+### 2.3 Add Check for Updates Button to SettingsView
+
+**File:** `Views/SettingsView.swift`
+
+In the About section (around line 246), add update check button:
+
+```swift
+// About Section
+Section {
+    LabeledContent("Version", value: "1.1.0")
+    LabeledContent("macOS", value: "13.0+ (Ventura)")
+
+    // Check for Updates button
+    HStack {
+        Text("Updates")
+        Spacer()
+        Button("Check for Updates...") {
+            UpdateManager.shared.checkForUpdates()
+        }
+        .disabled(!UpdateManager.shared.canCheckForUpdates)
+    }
+
+    Link(destination: URL(string: "https://github.com/shenglong209/MacGuard")!) {
+        HStack {
+            Text("GitHub Repository")
+            Spacer()
+            Image(systemName: "arrow.up.right.square")
+                .foregroundColor(.secondary)
+        }
+    }
+} header: {
+    Label("About", systemImage: "info.circle")
+}
+```
+
+### 2.4 Alternative: SwiftUI CheckForUpdatesView Component
+
+For reactive button state, create reusable component:
+
+**New File (optional):** `Views/CheckForUpdatesView.swift`
+
+```swift
+// CheckForUpdatesView.swift
+// MacGuard - Anti-Theft Alarm for macOS
+
+import SwiftUI
+import Sparkle
+
+/// SwiftUI view for "Check for Updates" button with reactive state
+struct CheckForUpdatesView: View {
+    @ObservedObject private var updateManager = UpdateManager.shared
+
+    var body: some View {
+        Button("Check for Updates...") {
+            updateManager.checkForUpdates()
+        }
+        .disabled(!updateManager.canCheckForUpdates)
+    }
+}
+```
+
+Then in SettingsView:
+
+```swift
+HStack {
+    Text("Updates")
+    Spacer()
+    CheckForUpdatesView()
+}
+```
+
+## File Changes Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `Managers/UpdateManager.swift` | Create | Sparkle integration singleton |
+| `MacGuardApp.swift` | Modify | Initialize UpdateManager |
+| `Views/SettingsView.swift` | Modify | Add Check for Updates button |
+| `Views/CheckForUpdatesView.swift` | Create (optional) | Reactive button component |
+
+## Verification Checklist
+
+- [ ] UpdateManager compiles with Sparkle import
+- [ ] App launches without crash
+- [ ] "Check for Updates" button appears in Settings
+- [ ] Button disabled during update check (reactive state)
+- [ ] Manual check shows "up to date" dialog (when no newer version)
+
+## Notes
+
+- UpdateManager is a singleton to ensure single Sparkle instance
+- `startingUpdater: true` begins automatic background checks
+- First auto-check occurs on 2nd launch (Sparkle default behavior)
+- Manual check via button always works immediately

--- a/plans/251218-1519-sparkle-auto-update/phase-03-release-automation.md
+++ b/plans/251218-1519-sparkle-auto-update/phase-03-release-automation.md
@@ -1,0 +1,266 @@
+# Phase 3: Release Automation
+
+## Tasks
+
+### 3.1 Create Initial appcast.xml
+
+**New File:** `appcast.xml` (repo root)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>MacGuard Updates</title>
+    <link>https://github.com/shenglong209/MacGuard</link>
+    <description>MacGuard anti-theft alarm for macOS</description>
+    <language>en</language>
+
+    <!-- Latest release will be added here by release script -->
+
+  </channel>
+</rss>
+```
+
+### 3.2 Create Release Script
+
+**New File:** `scripts/release.sh`
+
+```bash
+#!/bin/bash
+# release.sh - Automate MacGuard release with Sparkle signing
+# Usage: ./scripts/release.sh VERSION
+# Example: ./scripts/release.sh 1.2.0
+
+set -e
+
+VERSION=$1
+if [ -z "$VERSION" ]; then
+  echo "Usage: ./scripts/release.sh VERSION"
+  echo "Example: ./scripts/release.sh 1.2.0"
+  exit 1
+fi
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DMG_PATH="$PROJECT_DIR/dist/MacGuard-${VERSION}.dmg"
+APPCAST_PATH="$PROJECT_DIR/appcast.xml"
+SPARKLE_BIN="$PROJECT_DIR/.build/artifacts/sparkle/Sparkle/bin"
+
+echo "=== MacGuard Release v${VERSION} ==="
+
+# Step 1: Verify DMG exists
+if [ ! -f "$DMG_PATH" ]; then
+  echo "❌ DMG not found: $DMG_PATH"
+  echo "Run create-dmg.sh first"
+  exit 1
+fi
+
+# Step 2: Sign the DMG
+echo "📝 Signing DMG with EdDSA..."
+SIGNATURE=$("$SPARKLE_BIN/sign_update" "$DMG_PATH")
+echo "Signature: $SIGNATURE"
+
+# Extract signature and length from output
+# Format: sparkle:edSignature="xxx" length="yyy"
+ED_SIGNATURE=$(echo "$SIGNATURE" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
+FILE_LENGTH=$(echo "$SIGNATURE" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
+
+if [ -z "$ED_SIGNATURE" ]; then
+  echo "❌ Failed to extract signature"
+  exit 1
+fi
+
+echo "✅ EdDSA Signature: ${ED_SIGNATURE:0:20}..."
+echo "✅ File Length: $FILE_LENGTH bytes"
+
+# Step 3: Get current date in RFC 822 format
+PUB_DATE=$(date -R)
+
+# Step 4: Create new appcast item
+ITEM="    <item>
+      <title>Version ${VERSION}</title>
+      <link>https://github.com/shenglong209/MacGuard/releases/tag/v${VERSION}</link>
+      <sparkle:version>${VERSION//./}</sparkle:version>
+      <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+      <description><![CDATA[
+        <h3>What's New in ${VERSION}</h3>
+        <p>See release notes on GitHub.</p>
+      ]]></description>
+      <pubDate>${PUB_DATE}</pubDate>
+      <enclosure
+        url=\"https://github.com/shenglong209/MacGuard/releases/download/v${VERSION}/MacGuard-${VERSION}.dmg\"
+        sparkle:edSignature=\"${ED_SIGNATURE}\"
+        length=\"${FILE_LENGTH}\"
+        type=\"application/octet-stream\"
+      />
+    </item>"
+
+# Step 5: Insert item into appcast (after <language> line)
+echo "📄 Updating appcast.xml..."
+
+# Use awk to insert after </language> line
+awk -v item="$ITEM" '
+  /<\/language>/ {
+    print
+    print ""
+    print item
+    next
+  }
+  { print }
+' "$APPCAST_PATH" > "$APPCAST_PATH.tmp"
+mv "$APPCAST_PATH.tmp" "$APPCAST_PATH"
+
+echo "✅ appcast.xml updated"
+
+# Step 6: Create GitHub release
+echo "🚀 Creating GitHub release..."
+gh release create "v${VERSION}" \
+  "$DMG_PATH" \
+  --title "MacGuard v${VERSION}" \
+  --notes "## MacGuard v${VERSION}
+
+### Changes
+- See commit history for details
+
+### Installation
+1. Download MacGuard-${VERSION}.dmg
+2. Open DMG and drag MacGuard to Applications
+3. Launch from Applications folder
+
+### Auto-Update
+If you have a previous version installed, use Check for Updates in Settings."
+
+echo "✅ GitHub release created"
+
+# Step 7: Commit updated appcast
+echo "📦 Committing appcast..."
+git add "$APPCAST_PATH"
+git commit -m "chore: update appcast for v${VERSION}"
+git push
+
+echo ""
+echo "=== Release Complete ==="
+echo "✅ DMG signed and uploaded"
+echo "✅ appcast.xml updated and pushed"
+echo "✅ GitHub release: https://github.com/shenglong209/MacGuard/releases/tag/v${VERSION}"
+echo ""
+echo "Users will receive update notification on next app launch."
+```
+
+Make executable:
+```bash
+chmod +x scripts/release.sh
+```
+
+### 3.3 Update create-dmg.sh for Release Workflow
+
+Ensure `scripts/create-dmg.sh` outputs to `dist/MacGuard-${VERSION}.dmg` format.
+
+Current script already does this - verify version is passed correctly.
+
+### 3.4 GitHub Actions Workflow (Optional)
+
+**New File:** `.github/workflows/release.yml`
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Release
+        run: swift build -c release
+
+      - name: Create DMG
+        run: ./scripts/create-dmg.sh ${GITHUB_REF_NAME#v}
+
+      - name: Import Sparkle Key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          echo "$SPARKLE_PRIVATE_KEY" > sparkle-key.txt
+          .build/artifacts/sparkle/Sparkle/bin/generate_keys -f sparkle-key.txt
+          rm sparkle-key.txt
+
+      - name: Sign and Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/release.sh ${GITHUB_REF_NAME#v}
+```
+
+**Setup Required:**
+1. Add `SPARKLE_PRIVATE_KEY` to repo secrets (base64-encoded private key)
+2. Enable GitHub Actions in repo settings
+
+## Release Workflow
+
+### Manual Release (Recommended for First Release)
+
+```bash
+# 1. Update version in Info.plist and SettingsView.swift
+# CFBundleVersion: 2
+# CFBundleShortVersionString: 1.2.0
+
+# 2. Build release
+swift build -c release
+
+# 3. Create DMG
+./scripts/create-dmg.sh 1.2.0
+
+# 4. Run release script
+./scripts/release.sh 1.2.0
+
+# 5. Create PR for appcast update (or merge directly)
+```
+
+### Automated Release (After CI Setup)
+
+```bash
+# Just push a version tag
+git tag v1.2.0
+git push origin v1.2.0
+# GitHub Actions handles the rest
+```
+
+## File Changes Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `appcast.xml` | Create | Update feed (repo root) |
+| `scripts/release.sh` | Create | Signing and release automation |
+| `.github/workflows/release.yml` | Create (optional) | CI/CD automation |
+
+## Verification Checklist
+
+- [ ] appcast.xml created and committed
+- [ ] release.sh works with test DMG
+- [ ] Signature extracted correctly
+- [ ] appcast.xml updated with new item
+- [ ] GitHub release created with DMG attached
+- [ ] App can fetch appcast.xml from raw.githubusercontent.com
+- [ ] End-to-end update test passes
+
+## Testing Update Flow
+
+1. Install current version (e.g., 1.1.0)
+2. Create new release (1.2.0) using release.sh
+3. Launch old version
+4. Go to Settings → Check for Updates
+5. Verify update dialog appears with version 1.2.0
+6. Click Update → DMG downloads → App updates
+
+## Notes
+
+- First release with Sparkle requires manual EdDSA key setup (Phase 1)
+- GitHub Actions secret must contain exported private key
+- appcast.xml should be committed to main branch for raw.githubusercontent.com URL
+- Keep old release items in appcast for delta update generation (future)

--- a/plans/251218-1519-sparkle-auto-update/plan.md
+++ b/plans/251218-1519-sparkle-auto-update/plan.md
@@ -1,0 +1,106 @@
+# Sparkle Auto-Update Implementation Plan
+
+**Project:** MacGuard
+**Date:** 2025-12-18
+**Version:** 1.2.0 (target)
+
+---
+
+## Overview
+
+Implement Sparkle 2.x framework for automatic and manual update checking in MacGuard menu bar app. User preference: Auto + Manual checking via Settings UI.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     MacGuardApp                          │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │          SPUStandardUpdaterController             │  │
+│  │  - startingUpdater: true (auto-check enabled)     │  │
+│  │  - checkForUpdates() for manual trigger           │  │
+│  └───────────────────────────────────────────────────┘  │
+│                           │                              │
+│              ┌────────────┴────────────┐                │
+│              ▼                         ▼                │
+│      SettingsView               MenuBarView             │
+│   (Check for Updates)       (future: update badge)      │
+└─────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                    GitHub (appcast.xml)
+                    https://raw.githubusercontent.com/
+                    shenglong209/MacGuard/main/appcast.xml
+```
+
+## Integration Points
+
+| File | Change |
+|------|--------|
+| `Package.swift` | Add Sparkle dependency |
+| `MacGuardApp.swift` | Initialize SPUStandardUpdaterController |
+| `Views/SettingsView.swift` | Add "Check for Updates" button in About section |
+| `Info.plist` | Add SUFeedURL, SUPublicEDKey, update CFBundleVersion |
+| `appcast.xml` (new) | Update feed at repo root |
+| `scripts/release.sh` (new) | Automate signing and appcast generation |
+
+## Phases
+
+### Phase 1: SPM Integration & Key Setup
+**File:** `phase-01-spm-integration.md`
+
+### Phase 2: App Code Integration
+**File:** `phase-02-app-integration.md`
+
+### Phase 3: Release Automation
+**File:** `phase-03-release-automation.md`
+
+## Technical Decisions
+
+1. **SPM over CocoaPods/Carthage** - Native Swift package support, simpler integration
+2. **GitHub raw URL for appcast** - Free hosting, versioned with repo
+3. **EdDSA signing** - Mandatory in Sparkle 2.x, more secure than DSA
+4. **Auto-check enabled by default** - User expectation for security app
+
+## Testing Strategy
+
+1. Build with Sparkle dependency - verify compilation
+2. Test manual "Check for Updates" button works
+3. Create test release with higher version - verify update flow
+4. Test LSUIElement behavior - update dialogs appear correctly
+5. Verify signing workflow - signature validation passes
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| EdDSA key loss | Export to secure backup immediately after generation |
+| Update UI hidden (LSUIElement) | Test on clean system, dialogs should float |
+| Build failure with SPM | Verify Sparkle 2.x macOS 13+ compatibility |
+
+## Dependencies
+
+- Sparkle 2.x (latest stable)
+- Xcode 15+ (for SPM)
+- macOS 13.0+ (already required)
+
+## Success Criteria
+
+- [x] App builds with Sparkle framework
+- [ ] "Check for Updates" button in Settings works
+- [ ] Automatic update check on 2nd launch
+- [ ] EdDSA-signed DMG passes verification
+- [ ] appcast.xml hosted and accessible
+- [ ] End-to-end update flow tested
+
+**Phase 1 Status:** ✅ COMPLETE (2025-12-18 15:44)
+
+---
+
+## Implementation Order
+
+1. Phase 1 first (setup foundation)
+2. Phase 2 (code changes)
+3. Phase 3 (automation - can be deferred to first actual release)
+
+**Estimated complexity:** Medium - straightforward SPM integration, main work is release automation.

--- a/plans/251218-1519-sparkle-auto-update/research/researcher-01-sparkle-spm.md
+++ b/plans/251218-1519-sparkle-auto-update/research/researcher-01-sparkle-spm.md
@@ -1,0 +1,283 @@
+# Sparkle 2.x Framework Integration Research
+
+**Date:** 2025-12-18
+**Focus:** Swift Package Manager integration, SwiftUI compatibility, Info.plist config, LSUIElement considerations, update mechanisms
+
+---
+
+## 1. Swift Package Manager Integration
+
+### Installation Steps
+```
+1. Xcode → File → Add Packages…
+2. Repository URL: https://github.com/sparkle-project/Sparkle
+3. Accept default package options (auto-updates enabled)
+4. Tools location: Right-click Sparkle in project navigator → Show in Finder
+   Path: ../artifacts/sparkle/Sparkle/bin/
+```
+
+### Key Tools
+- `generate_keys` - Creates EdDSA keypair (private → Keychain, public → Info.plist)
+- `sign_update` - Signs update archives for distribution
+
+---
+
+## 2. SwiftUI Compatibility & SPUStandardUpdaterController
+
+### Basic Setup (SwiftUI App)
+
+```swift
+import Sparkle
+
+@main
+struct MacGuardApp: App {
+    private let updaterController: SPUStandardUpdaterController
+
+    init() {
+        // Initialize updater - starts automatically if startingUpdater: true
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesView(updater: updaterController.updater)
+            }
+        }
+    }
+}
+```
+
+### Menu Bar App Integration (SwiftUI)
+
+```swift
+@main
+struct MenuBarApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        Settings { EmptyView() }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem?
+    private let updaterController: SPUStandardUpdaterController
+
+    override init() {
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        super.init()
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(
+            title: "Check for Updates…",
+            action: #selector(checkForUpdates),
+            keyEquivalent: ""
+        ))
+        statusItem?.menu = menu
+    }
+
+    @objc func checkForUpdates() {
+        updaterController.checkForUpdates(nil)
+    }
+}
+```
+
+### SwiftUI Check Updates View with State Binding
+
+```swift
+final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+
+    init(updater: SPUUpdater) {
+        updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+}
+
+struct CheckForUpdatesView: View {
+    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    private let updater: SPUUpdater
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        self.viewModel = CheckForUpdatesViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates…", action: updater.checkForUpdates)
+            .disabled(!viewModel.canCheckForUpdates)
+    }
+}
+```
+
+---
+
+## 3. Info.plist Configuration
+
+### Required Keys
+```xml
+<key>SUFeedURL</key>
+<string>https://example.com/appcast.xml</string>
+
+<key>SUPublicEDKey</key>
+<string>YOUR_BASE64_ENCODED_PUBLIC_KEY</string>
+```
+
+### Automatic Update Control
+```xml
+<!-- Enable/disable automatic checks -->
+<key>SUEnableAutomaticChecks</key>
+<true/>  <!-- YES: auto-enable, NO: disable, omit: prompt user on 2nd launch -->
+
+<!-- Check interval (seconds, min 3600, default 86400) -->
+<key>SUScheduledCheckInterval</key>
+<integer>86400</integer>
+
+<!-- Silent background updates (default NO) -->
+<key>SUAutomaticallyUpdate</key>
+<true/>
+
+<!-- Allow users to enable automatic updates (default YES) -->
+<key>SUAllowsAutomaticUpdates</key>
+<true/>
+```
+
+### Additional Settings
+```xml
+<!-- Verify update before extraction (Sparkle 2.7+) -->
+<key>SUVerifyUpdateBeforeExtraction</key>
+<true/>
+
+<!-- Show release notes (default YES) -->
+<key>SUShowReleaseNotes</key>
+<true/>
+
+<!-- Enable system profiling (default NO) -->
+<key>SUEnableSystemProfiling</key>
+<false/>
+```
+
+### Sandboxing (if needed)
+```xml
+<key>SUEnableInstallerLauncherService</key>
+<true/>  <!-- Required for sandboxed apps -->
+
+<key>SUEnableDownloaderService</key>
+<true/>  <!-- If app lacks network entitlement -->
+```
+
+---
+
+## 4. LSUIElement (Menu Bar App) Considerations
+
+**Official Documentation:** No specific LSUIElement guidance found in Sparkle docs.
+
+### Known Behaviors
+- Sparkle works with `LSUIElement=true` apps
+- Update UI appears as floating windows (no dock icon needed)
+- First launch check skipped (check happens on 2nd launch by default)
+
+### Testing Update Timing
+```bash
+# Clear last check time to trigger immediate check
+defaults delete com.yourapp.bundleid SULastCheckTime
+```
+
+### Potential Issues
+- Update dialogs may lack app context if dock icon hidden
+- Users might miss update notifications without dock presence
+- Consider more prominent update prompts in menu bar UI
+
+---
+
+## 5. Programmatic vs Automatic Update Checking
+
+### Automatic (Default Behavior)
+- **No code required** after initialization with `startingUpdater: true`
+- Checks every 24 hours (configurable via `SUScheduledCheckInterval`)
+- First check on **2nd launch**, not first launch
+- Runs in background via `checkForUpdatesInBackground()`
+
+### Programmatic Checking
+
+**Manual User-Triggered Check:**
+```swift
+updaterController.checkForUpdates(nil)
+```
+
+**Check Update Availability:**
+```swift
+let canCheck = updaterController.updater.canCheckForUpdates
+```
+
+**Reset Update Cycle (after settings change):**
+```swift
+updaterController.updater.resetUpdateCycleAfterShortDelay()
+```
+
+### Best Practices
+- **DO NOT** call `checkForUpdatesInBackground()` manually - Sparkle handles this
+- **DO** use `checkForUpdates()` for user-initiated checks (menu items)
+- **DO** call `resetUpdateCycleAfterShortDelay()` when users change feed URLs
+- **DO** configure settings in Info.plist, not programmatically
+
+### Delegate Customization
+
+```swift
+class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        // Dynamic feed URL if not in Info.plist
+        return "https://example.com/appcast.xml"
+    }
+
+    func updater(_ updater: SPUUpdater,
+                 willScheduleUpdateCheckAfterDelay delay: TimeInterval) {
+        // Called before automatic background check
+    }
+}
+
+// Initialize with delegate
+updaterController = SPUStandardUpdaterController(
+    startingUpdater: true,
+    updaterDelegate: UpdaterDelegate(),
+    userDriverDelegate: nil
+)
+```
+
+---
+
+## Summary
+
+**SPM Integration:** Single-step Xcode package addition, tools in artifacts folder.
+
+**SwiftUI:** Full support via `SPUStandardUpdaterController`, initialize in App struct, use `@NSApplicationDelegateAdaptor` for menu bar apps.
+
+**Info.plist:** Requires `SUFeedURL` + `SUPublicEDKey` minimum, extensive customization via `SU*` keys.
+
+**LSUIElement:** Works but no official docs - update UI floats, test with cleared defaults, consider UX for dock-less apps.
+
+**Update Modes:** Automatic default (24hr), programmatic for user-triggered checks, avoid manual background calls.
+
+---
+
+## Unresolved Questions
+
+1. Best practices for LSUIElement update notifications (in-menu vs dialog)?
+2. Recommended approach for beta channel switching in menu bar apps?
+3. Performance impact of `SUAutomaticallyUpdate` on menu bar apps?

--- a/plans/251218-1519-sparkle-auto-update/research/researcher-02-appcast-signing.md
+++ b/plans/251218-1519-sparkle-auto-update/research/researcher-02-appcast-signing.md
@@ -1,0 +1,334 @@
+# Sparkle Appcast & EdDSA Signing Research
+
+## 1. Appcast.xml Format
+
+### Required Fields
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>MacGuard Changelog</title>
+    <link>https://github.com/yourusername/MacGuard</link>
+    <description>MacGuard Updates</description>
+    <language>en</language>
+
+    <item>
+      <title>Version 1.0.1</title>
+      <link>https://github.com/yourusername/MacGuard/releases/tag/v1.0.1</link>
+      <sparkle:version>1.0.1</sparkle:version>
+      <sparkle:shortVersionString>1.0.1</sparkle:shortVersionString>
+      <description><![CDATA[
+        <h3>Bug Fixes</h3>
+        <ul>
+          <li>Fixed Bluetooth detection</li>
+          <li>Improved menu bar UI</li>
+        </ul>
+      ]]></description>
+      <pubDate>Wed, 18 Dec 2025 10:00:00 +0000</pubDate>
+      <enclosure
+        url="https://github.com/yourusername/MacGuard/releases/download/v1.0.1/MacGuard-1.0.1.dmg"
+        sparkle:edSignature="BASE64_SIGNATURE_HERE"
+        length="12345678"
+        type="application/octet-stream"
+      />
+    </item>
+  </channel>
+</rss>
+```
+
+### Critical Fields
+- `<sparkle:version>`: CFBundleVersion (must increment)
+- `<sparkle:shortVersionString>`: CFBundleShortVersionString (user-facing)
+- `<enclosure url="">`: HTTPS download URL (required by ATS)
+- `sparkle:edSignature`: EdDSA signature (mandatory for security)
+- `length`: File size in bytes
+- `<pubDate>`: RFC 822 format
+
+### Optional Advanced Fields
+- `<sparkle:releaseNotesLink>`: External HTML changelog
+- `<sparkle:minimumSystemVersion>`: e.g., "10.13.0"
+- `<sparkle:maximumSystemVersion>`: Restrict to max version
+- `<sparkle:criticalUpdate>`: Force install, no skip option
+- `<sparkle:minimumAutoupdateVersion>`: Block auto-install, show UI instead
+- `<sparkle:phasedRolloutInterval>`: Seconds between rollout groups (7 groups)
+- `<sparkle:channel>`: Beta/staged releases (requires delegate)
+
+## 2. EdDSA Key Generation
+
+### One-Time Setup
+
+```bash
+# Download Sparkle distribution
+curl -LO https://github.com/sparkle-project/Sparkle/releases/latest/download/Sparkle-2.x.x.tar.xz
+tar -xf Sparkle-2.x.x.tar.xz
+
+# Generate EdDSA key pair (run once)
+./bin/generate_keys
+
+# Output:
+# Private key saved to Mac Keychain
+# Public key (base64): AbCdEf1234567890...
+```
+
+### Add Public Key to Info.plist
+
+```xml
+<key>SUPublicEDKey</key>
+<string>AbCdEf1234567890...</string>
+```
+
+### Key Management Commands
+
+```bash
+# Export private key to file
+./bin/generate_keys -x private-key.txt
+
+# Import private key from file
+./bin/generate_keys -f private-key.txt
+
+# Regenerate to view public key again
+./bin/generate_keys
+```
+
+**Security**: Store private key in Keychain or secure CI/CD secrets. Never commit to repo.
+
+## 3. Signing DMG Files
+
+### Manual Signing
+
+```bash
+# Sign update file
+./bin/sign_update MacGuard-1.0.1.dmg
+
+# Output:
+# sparkle:edSignature="mc3N8JqZHGzFYLl6..." length="12345678"
+```
+
+### Sign with External Key File
+
+```bash
+./bin/sign_update MacGuard-1.0.1.dmg -s private-key.txt
+```
+
+### Automated Appcast Generation
+
+```bash
+# Create updates folder structure
+mkdir -p updates_folder
+cp MacGuard-1.0.1.dmg updates_folder/
+
+# Optional: Add release notes HTML (same basename)
+echo "<h3>Bug Fixes</h3>..." > updates_folder/MacGuard-1.0.1.html
+
+# Generate appcast (auto-signs, creates deltas)
+./bin/generate_appcast updates_folder/
+
+# Output:
+# - appcast.xml (uses SUFeedURL from Info.plist)
+# - .delta files for incremental updates
+# - All signatures embedded
+```
+
+### Supported Archive Formats
+
+```bash
+# ZIP (preserves symlinks)
+ditto -c -k --sequesterRsrc --keepParent MacGuard.app MacGuard.zip
+
+# TAR (strips extended attributes)
+tar --no-xattrs -cJf MacGuard.tar.xz MacGuard.app
+
+# DMG (APFS + lzfse compression recommended)
+# Use Disk Utility or hdiutil
+```
+
+## 4. Hosting on GitHub
+
+### Option A: GitHub Releases (Recommended)
+
+```bash
+# DMG URL pattern:
+https://github.com/USERNAME/REPO/releases/download/v1.0.1/MacGuard-1.0.1.dmg
+
+# Advantages:
+# - Native release management
+# - Download statistics
+# - Asset management UI
+```
+
+### Option B: GitHub Pages
+
+```bash
+# Appcast URL:
+https://USERNAME.github.io/REPO/appcast.xml
+
+# Setup:
+# 1. Enable GitHub Pages in repo settings
+# 2. Choose branch (e.g., gh-pages or main/docs)
+# 3. Upload appcast.xml to published directory
+```
+
+### Option C: Raw githubusercontent.com
+
+```bash
+# Appcast URL:
+https://raw.githubusercontent.com/USERNAME/REPO/main/appcast.xml
+
+# Limitations:
+# - No caching control
+# - Not recommended for production (use GitHub Pages instead)
+```
+
+### Info.plist Configuration
+
+```xml
+<key>SUFeedURL</key>
+<string>https://raw.githubusercontent.com/USERNAME/REPO/main/appcast.xml</string>
+```
+
+## 5. Automating Appcast Generation
+
+### GitHub Actions Workflow Example
+
+```yaml
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Sparkle Tools
+        run: |
+          curl -LO https://github.com/sparkle-project/Sparkle/releases/latest/download/Sparkle-2.6.4.tar.xz
+          tar -xf Sparkle-2.6.4.tar.xz
+
+      - name: Import EdDSA Private Key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          echo "$SPARKLE_PRIVATE_KEY" > private-key.txt
+          ./bin/generate_keys -f private-key.txt
+
+      - name: Build DMG
+        run: |
+          # Your DMG build script
+          ./build-dmg.sh
+
+      - name: Sign Update
+        run: |
+          SIGNATURE=$(./bin/sign_update dist/MacGuard-${{ github.ref_name }}.dmg)
+          echo "SIGNATURE=$SIGNATURE" >> $GITHUB_ENV
+
+      - name: Generate Appcast
+        run: |
+          mkdir -p updates
+          cp dist/MacGuard-${{ github.ref_name }}.dmg updates/
+          ./bin/generate_appcast updates/ -o appcast.xml
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/MacGuard-${{ github.ref_name }}.dmg
+            appcast.xml
+
+      - name: Update Appcast URL in File
+        run: |
+          # Update enclosure URL to GitHub release URL
+          sed -i '' "s|url=\".*\"|url=\"https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/MacGuard-${{ github.ref_name }}.dmg\"|" appcast.xml
+
+      - name: Commit Updated Appcast
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add appcast.xml
+          git commit -m "Update appcast for ${{ github.ref_name }}"
+          git push
+```
+
+### Shell Script Automation
+
+```bash
+#!/bin/bash
+# release.sh - Automate Sparkle release process
+
+set -e
+
+VERSION=$1
+DMG_PATH="dist/MacGuard-${VERSION}.dmg"
+UPDATES_DIR="updates"
+APPCAST="appcast.xml"
+
+# Validate
+if [ -z "$VERSION" ]; then
+  echo "Usage: ./release.sh VERSION"
+  exit 1
+fi
+
+# Setup
+mkdir -p "$UPDATES_DIR"
+cp "$DMG_PATH" "$UPDATES_DIR/"
+
+# Generate appcast with signatures
+./bin/generate_appcast "$UPDATES_DIR/" -o "$APPCAST"
+
+# Upload to GitHub release
+gh release create "v${VERSION}" \
+  "$DMG_PATH" \
+  "$APPCAST" \
+  --title "Version ${VERSION}" \
+  --notes-file CHANGELOG.md
+
+# Update appcast URL to point to GitHub release
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+sed -i '' "s|url=\".*\\.dmg\"|url=\"https://github.com/${REPO}/releases/download/v${VERSION}/MacGuard-${VERSION}.dmg\"|" "$APPCAST"
+
+# Commit updated appcast to repo
+git add "$APPCAST"
+git commit -m "Update appcast for v${VERSION}"
+git push
+
+echo "✓ Release v${VERSION} published"
+echo "✓ Appcast updated at: https://raw.githubusercontent.com/${REPO}/main/appcast.xml"
+```
+
+### Makefile Integration
+
+```makefile
+SPARKLE_BIN = ./Sparkle/bin
+VERSION = $(shell defaults read $(PWD)/MacGuard/Info.plist CFBundleShortVersionString)
+DMG = dist/MacGuard-$(VERSION).dmg
+
+.PHONY: release
+release: $(DMG)
+	mkdir -p updates
+	cp $(DMG) updates/
+	$(SPARKLE_BIN)/generate_appcast updates/ -o appcast.xml
+	@echo "Appcast generated. Upload $(DMG) and appcast.xml"
+
+.PHONY: sign
+sign: $(DMG)
+	$(SPARKLE_BIN)/sign_update $(DMG)
+```
+
+## Unresolved Questions
+
+1. **Delta updates**: How large should app be before delta updates provide benefit? (Sparkle auto-generates for "large apps")
+2. **Rollback strategy**: If critical bug in new version, best way to revert appcast to previous version?
+3. **Multi-channel testing**: Should beta channel use separate appcast.xml or same file with channel tags?
+4. **Key rotation**: Exact process for rotating EdDSA keys when compromised (docs mention support but not procedure)
+5. **Phased rollout monitoring**: How to track which user group received update during phased rollout?
+
+## Sources
+
+- [Sparkle Documentation](https://sparkle-project.org/documentation/)
+- [Sparkle Publishing Guide](https://sparkle-project.org/documentation/publishing/)
+- [Sparkle GitHub Repository](https://github.com/sparkle-project/Sparkle)

--- a/plans/reports/code-reviewer-251218-1540-phase-01-review.md
+++ b/plans/reports/code-reviewer-251218-1540-phase-01-review.md
@@ -1,0 +1,146 @@
+# Code Review: MacGuard Phase 1 Sparkle Auto-Update Integration
+
+**Reviewer:** code-reviewer
+**Date:** 2025-12-18 15:40
+**Scope:** Phase 1 SPM Integration & Configuration
+
+---
+
+## Summary
+
+**0 critical issues, 1 warning, 2 suggestions**
+
+Phase 1 Sparkle integration mostly correct. SUPublicEDKey format valid, SUFeedURL uses HTTPS, Package.swift dependency format correct. Build succeeds with warning about non-existent appcast.xml (expected at this phase). Version bumps consistent.
+
+---
+
+## Scope
+
+**Files Reviewed:**
+- `Package.swift` (Sparkle dependency added)
+- `Info.plist` (Sparkle config, version bump to 1.2.0)
+- `Views/SettingsView.swift` (version display update)
+
+**Lines Modified:** ~45 additions/changes
+**Review Focus:** Phase 1 changes only (SPM + config)
+**Updated Plans:** `/Users/shenglong/DATA/XProject/MacGuard/plans/251218-1519-sparkle-auto-update/phase-01-spm-integration.md`
+
+---
+
+## Overall Assessment
+
+Implementation follows plan spec correctly. No security vulnerabilities detected. Configuration keys match Sparkle 2.x requirements. YAGNI/KISS/DRY principles adhered to - no over-engineering.
+
+---
+
+## Critical Issues
+
+None.
+
+---
+
+## High Priority Findings
+
+None.
+
+---
+
+## Medium Priority Improvements
+
+**1. Warning: Non-existent exclude path in Package.swift**
+
+```
+warning: 'macguard': Invalid Exclude '/Users/shenglong/DATA/XProject/MacGuard/appcast.xml': File not found.
+```
+
+**Impact:** Build warning noise, no functional impact
+**Root Cause:** `appcast.xml` added to exclude list but not created yet (Phase 3 deliverable)
+**Recommendation:** Acceptable for Phase 1, will resolve when Phase 3 creates appcast.xml
+
+---
+
+## Low Priority Suggestions
+
+**1. SUPublicEDKey should be verified against actual generated key**
+
+Current value: `I7s26R56gqkm2GqhPOLdjcyK4YGcuEbSWsRBTEumlb8=`
+
+**Validation:**
+- Format: Valid base64 (44 chars, ends with `=`)
+- Ed25519 public keys: 32 bytes = 44 base64 chars ✓
+
+**Recommendation:** Ensure this matches actual key from `generate_keys` output. If placeholder, replace before Phase 3 release automation.
+
+**2. Additional excludes added beyond plan spec**
+
+Plan specified: `plans`, `scripts`, `appcast.xml`
+Actual added: `plans`, `scripts`, `appcast.xml`, `dist`, `featured-image.png`
+
+**Impact:** None - sensible additions
+**Recommendation:** Update plan docs to reflect actual excludes for future reference
+
+---
+
+## Positive Observations
+
+1. **Correct Sparkle 2.x configuration keys**
+   - SUFeedURL, SUPublicEDKey, SUEnableAutomaticChecks, SUScheduledCheckInterval, SUShowReleaseNotes all present
+   - No deprecated 1.x keys used
+
+2. **HTTPS feed URL**
+   - Uses `https://raw.githubusercontent.com/` (secure)
+
+3. **Version strategy correct**
+   - CFBundleVersion: 1→2 (integer increment)
+   - CFBundleShortVersionString: 1.0.0→1.2.0 (semantic)
+   - SettingsView.swift: 1.1.0→1.2.0 (consistent)
+
+4. **Dependency format correct**
+   - Uses `.package(url:, from:)` with version constraint "2.0.0"
+   - Product name "Sparkle" matches official package
+
+5. **Build succeeds**
+   - Release build completes in 0.51s
+   - Only warning is expected appcast.xml absence
+
+---
+
+## Recommended Actions
+
+1. **Phase 1 Complete:** Mark all tasks done in plan file
+2. **Verify SUPublicEDKey:** Confirm matches actual generated key (or regenerate if placeholder)
+3. **Proceed to Phase 2:** App integration (SPM foundation solid)
+
+---
+
+## Metrics
+
+- **Type Coverage:** N/A (config-only changes)
+- **Test Coverage:** N/A (no code changes requiring tests)
+- **Linting Issues:** 0
+- **Build Warnings:** 1 (expected, non-blocking)
+- **Security Issues:** 0
+
+---
+
+## Phase 1 Verification Checklist
+
+Per plan file `/Users/shenglong/DATA/XProject/MacGuard/plans/251218-1519-sparkle-auto-update/phase-01-spm-integration.md`:
+
+- ✅ Package.swift updated with Sparkle dependency
+- ✅ `swift build` succeeds (warning acceptable)
+- ⚠️ EdDSA keypair generated (cannot verify from code review)
+- ⚠️ Public key added to Info.plist (format valid, origin unverified)
+- ⚠️ Private key backed up securely (cannot verify)
+- ✅ SUFeedURL points to correct appcast location
+- ✅ CFBundleVersion strategy documented and implemented
+
+Legend: ✅ Verified | ⚠️ Cannot verify from code | ❌ Missing
+
+---
+
+## Unresolved Questions
+
+1. Was EdDSA keypair actually generated using `generate_keys` tool?
+2. Is current SUPublicEDKey value (`I7s26R56gqkm2GqhPOLdjcyK4YGcuEbSWsRBTEumlb8=`) from actual keypair or placeholder?
+3. If real keypair, is private key backed up per plan section 1.3?

--- a/plans/reports/docs-manager-251218-1544-sparkle-phase1.md
+++ b/plans/reports/docs-manager-251218-1544-sparkle-phase1.md
@@ -1,0 +1,57 @@
+# Documentation Update Report: Sparkle Auto-Update Phase 1
+
+**Subagent:** docs-manager
+**ID:** a1f372a
+**Date:** 2025-12-18 15:44
+**Phase:** Phase 1: SPM Integration & Key Setup (DONE)
+
+## Status: SKIPPED
+
+### Findings
+
+No `docs/` directory exists in repository.
+
+### Action Taken
+
+**SKIPPED** - No documentation updates performed per instructions ("If no docs exist, skip doc updates").
+
+### Changed Files (Phase 1)
+
+For reference, following files were modified in Phase 1:
+- `/Users/shenglong/DATA/XProject/MacGuard/Package.swift` - Added Sparkle 2.8.1 dependency
+- `/Users/shenglong/DATA/XProject/MacGuard/Info.plist` - Added SUFeedURL, SUPublicEDKey, SUEnableAutomaticChecks, version bumped to 1.2.0
+- `/Users/shenglong/DATA/XProject/MacGuard/Views/SettingsView.swift` - Version display updated
+
+### Key Integration Details (Not Documented)
+
+Since no docs exist, following details were NOT documented:
+
+**Sparkle Configuration:**
+- Version: 2.8.1 (SPM)
+- EdDSA Public Key: `I7s26R56gqkm2GqhPOLdjcyK4YGcuEbSWsRBTEumlb8=`
+- Feed URL: `https://raw.githubusercontent.com/shenglong209/MacGuard/main/appcast.xml`
+- Auto-check: Enabled (24h interval)
+- App Version: Bumped to 1.2.0
+
+**Would-be Documentation Targets (if docs existed):**
+- `docs/deployment-guide.md` - Release process with appcast.xml updates
+- `docs/system-architecture.md` - Sparkle integration architecture
+- `docs/project-overview-pdr.md` - Auto-update feature requirements
+
+### Recommendations
+
+1. **README.md Update**: Consider adding "Auto-Update" to Features section
+2. **Future Phases**: When Phase 2 (updater integration) completes, create `docs/` folder with:
+   - `deployment-guide.md` - Appcast generation workflow
+   - `system-architecture.md` - Sparkle integration details
+   - `release-checklist.md` - Version bump + signing steps
+
+### Notes
+
+- Repository has README.md with comprehensive project info
+- No structured docs/ directory yet
+- Token-efficient approach: Skip unnecessary file creation
+
+## Unresolved Questions
+
+None. Instructions clear: skip if no docs exist.

--- a/plans/reports/tester-251218-1536-sparkle-integration-tests.md
+++ b/plans/reports/tester-251218-1536-sparkle-integration-tests.md
@@ -1,0 +1,225 @@
+# Test Report: Sparkle Framework Integration (Phase 1)
+
+**Date:** 2025-12-18
+**Tester:** tester subagent
+**Context:** MacGuard v1.2.0 - Sparkle 2.x auto-update integration testing
+**Scope:** Phase 1 infrastructure - SPM dependency, build verification, Info.plist config
+
+---
+
+## Test Results Summary
+
+**Overall Status:** ✅ **PASS**
+**Tests Executed:** 4
+**Passed:** 4
+**Failed:** 0
+**Warnings:** 1 (non-blocking)
+
+---
+
+## Test Execution Details
+
+### Test 1: Debug Build Compilation ✅ PASS
+
+**Command:**
+```bash
+swift build
+```
+
+**Result:**
+- Build completed successfully in 0.41s
+- No compilation errors
+- Sparkle framework linked correctly
+
+**Warning (Non-blocking):**
+```
+warning: 'macguard': Invalid Exclude '/Users/shenglong/DATA/XProject/MacGuard/appcast.xml': File not found.
+```
+**Note:** Expected warning - `appcast.xml` excluded in Package.swift but doesn't exist yet (will be created in Phase 2/3).
+
+---
+
+### Test 2: Release Build Compilation ✅ PASS
+
+**Command:**
+```bash
+swift build -c release
+```
+
+**Result:**
+- Build completed successfully in 16.05s
+- Binary created: `.build/release/MacGuard` (1.2 MB, arm64)
+- Sparkle framework linked: `@rpath/Sparkle.framework/Versions/B/Sparkle (compatibility version 1.6.0, current version 2.8.1)`
+- No compilation errors
+
+**Binary Verification:**
+```
+File: Mach-O 64-bit executable arm64
+Size: 1.2 MB
+Path: /Users/shenglong/DATA/XProject/MacGuard/.build/release/MacGuard
+```
+
+**Linked Libraries (Sparkle):**
+```
+@rpath/Sparkle.framework/Versions/B/Sparkle (compatibility version 1.6.0, current version 2.8.1)
+```
+
+---
+
+### Test 3: Sparkle Binary Tools Availability ✅ PASS
+
+**Path:** `.build/artifacts/sparkle/Sparkle/bin/`
+
+**Tools Found:**
+- ✅ `BinaryDelta` (1.4 MB) - Binary delta patch generation
+- ✅ `generate_appcast` (2.1 MB) - Appcast XML generation
+- ✅ `generate_keys` (1.3 MB) - EdDSA key pair generation
+- ✅ `sign_update` (1.4 MB) - Update package signing
+- ✅ `old_dsa_scripts/` - Legacy DSA tools (deprecated)
+
+**Verification:**
+```bash
+ls -lh .build/artifacts/sparkle/Sparkle/bin/
+```
+All required tools present and executable.
+
+---
+
+### Test 4: Info.plist Sparkle Configuration ✅ PASS
+
+**File:** `/Users/shenglong/DATA/XProject/MacGuard/Info.plist`
+
+**Required Keys Verified:**
+
+| Key | Expected | Actual | Status |
+|-----|----------|--------|--------|
+| `SUFeedURL` | Valid URL | `https://raw.githubusercontent.com/shenglong209/MacGuard/main/appcast.xml` | ✅ |
+| `SUPublicEDKey` | Base64 EdDSA key | `I7s26R56gqkm2GqhPOLdjcyK4YGcuEbSWsRBTEumlb8=` | ✅ |
+| `SUEnableAutomaticChecks` | `true` | `true` | ✅ |
+| `SUScheduledCheckInterval` | Integer (seconds) | `86400` (24 hours) | ✅ |
+| `SUShowReleaseNotes` | `true` | `true` | ✅ |
+
+**Additional Config:**
+- Version: `1.2.0` (CFBundleShortVersionString)
+- Build: `2` (CFBundleVersion)
+- Bundle ID: `com.shenglong.macguard`
+
+**Verification Commands:**
+```bash
+/usr/libexec/PlistBuddy -c "Print :SUFeedURL" Info.plist
+/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" Info.plist
+/usr/libexec/PlistBuddy -c "Print :SUEnableAutomaticChecks" Info.plist
+/usr/libexec/PlistBuddy -c "Print :SUScheduledCheckInterval" Info.plist
+```
+
+---
+
+## Infrastructure Validation
+
+### Package.swift Dependency ✅
+```swift
+dependencies: [
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0")
+]
+```
+
+### Target Configuration ✅
+```swift
+.executableTarget(
+    name: "MacGuard",
+    dependencies: [
+        .product(name: "Sparkle", package: "Sparkle")
+    ]
+)
+```
+
+### Sparkle Artifacts Structure ✅
+```
+.build/artifacts/sparkle/Sparkle/
+├── bin/                                    # CLI tools
+│   ├── generate_appcast
+│   ├── generate_keys
+│   ├── sign_update
+│   └── BinaryDelta
+├── Sparkle.xcframework/                    # Framework binary
+│   └── macos-arm64_x86_64/
+│       └── Sparkle.framework/
+└── SampleAppcast.xml                       # Template
+```
+
+---
+
+## Coverage Analysis
+
+### Phase 1 Scope Coverage: 100%
+
+**Completed:**
+- [x] Sparkle dependency added to Package.swift
+- [x] Debug build compiles with Sparkle linked
+- [x] Release build compiles with Sparkle linked
+- [x] Sparkle binary tools accessible at expected path
+- [x] Info.plist contains all required Sparkle keys
+- [x] EdDSA public key configured
+- [x] Update feed URL configured
+- [x] Auto-check settings configured
+
+**Not in Scope (Phase 2/3):**
+- UpdateManager.swift implementation
+- UI integration (menu bar "Check for Updates")
+- Appcast.xml generation
+- Code signing for updates
+- GitHub release automation
+
+---
+
+## Issues & Warnings
+
+### Non-Blocking Warnings
+
+1. **appcast.xml Exclude Warning**
+   - **Severity:** Low
+   - **Message:** `Invalid Exclude '/Users/shenglong/DATA/XProject/MacGuard/appcast.xml': File not found`
+   - **Impact:** None - file will be created in Phase 2/3
+   - **Action:** Remove from Package.swift excludes once created
+
+---
+
+## Performance Metrics
+
+| Build Type | Duration | Binary Size |
+|------------|----------|-------------|
+| Debug | 0.41s | - |
+| Release | 16.05s | 1.2 MB |
+
+**Note:** Release build includes Sparkle framework compilation (first build took longer, subsequent builds cached).
+
+---
+
+## Recommendations
+
+### Immediate Actions (Phase 2 Preparation)
+1. Create UpdateManager.swift to initialize Sparkle
+2. Add "Check for Updates" menu item to MenuBarView
+3. Generate appcast.xml with `generate_appcast` tool
+4. Remove appcast.xml from Package.swift excludes
+
+### Best Practices Observed
+- ✅ Using Sparkle 2.x (latest major version)
+- ✅ EdDSA signing (modern, recommended over DSA)
+- ✅ 24-hour auto-check interval (reasonable default)
+- ✅ Release notes enabled for transparency
+- ✅ Public key stored in Info.plist (standard approach)
+
+---
+
+## Conclusion
+
+Phase 1 (SPM Integration & Key Setup) **fully functional**. All build processes succeed, Sparkle framework correctly linked, tools accessible, Info.plist properly configured. No blocking issues.
+
+**Ready for Phase 2:** UpdateManager implementation and UI integration.
+
+---
+
+## Unresolved Questions
+
+None. All Phase 1 requirements verified and passing.


### PR DESCRIPTION
## Summary
- Add Sparkle 2.8.1 dependency via SPM for auto-update functionality
- Configure Info.plist with SUFeedURL, SUPublicEDKey, and update settings
- Generate EdDSA keypair for release signing
- Update version to 1.2.0 (CFBundleVersion: 2)

## Phase 1: SPM Integration & Key Setup
This PR completes Phase 1 of the Sparkle Auto-Update implementation plan.

### Changes
- `Package.swift` - Added Sparkle dependency, updated excludes
- `Info.plist` - Added Sparkle config (SUFeedURL, SUPublicEDKey, etc.)
- `Views/SettingsView.swift` - Updated version display to 1.2.0

### Test Plan
- [x] Debug build compiles successfully
- [x] Release build compiles successfully
- [x] Sparkle 2.8.1 framework linked correctly
- [x] Binary tools available at `.build/artifacts/sparkle/Sparkle/bin/`
- [x] All Info.plist Sparkle keys verified

### Next Steps
Phase 2: App Code Integration (UpdateManager + Settings UI button)