### PR TITLE
feat: configurable countdown duration and misc improvements

### DIFF
--- a/Managers/AlarmStateManager.swift
+++ b/Managers/AlarmStateManager.swift
@@ -15,10 +15,6 @@ class AlarmStateManager: ObservableObject {
     @Published var countdownSeconds: Int = 3
     @Published var hasAccessibilityPermission = false
 
-    // MARK: - Configuration
-
-    private let countdownDuration = 3
-
     // MARK: - Public Managers (for UI access)
 
     let bluetoothManager = BluetoothProximityManager()
@@ -213,14 +209,22 @@ class AlarmStateManager: ObservableObject {
             return
         }
 
-        state = .triggered
-        countdownSeconds = countdownDuration
+        let duration = AppSettings.shared.countdownDuration
+        countdownSeconds = duration
 
         // Show fullscreen overlay
         overlayController.show(alarmManager: self)
 
-        startCountdown()
-        print("[MacGuard] Triggered - countdown started")
+        // If countdown is 0, skip directly to alarm
+        if duration == 0 {
+            audioManager.playAlarm()
+            state = .alarming
+            print("[MacGuard] Triggered - immediate alarm (no countdown)")
+        } else {
+            state = .triggered
+            startCountdown()
+            print("[MacGuard] Triggered - countdown started (\(duration)s)")
+        }
     }
 
     /// Immediately trigger alarm (e.g., for lid close)

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -63,6 +63,7 @@ class AppSettings: ObservableObject {
     @AppStorage("alarmSound") private var alarmSoundRaw: String = AlarmSound.dontTouchMyMac.rawValue
     @AppStorage("alarmVolume") var alarmVolume: Double = 1.0
     @AppStorage("customSoundPath") var customSoundPath: String = ""
+    @AppStorage("countdownDuration") var countdownDuration: Int = 3
     @AppStorage("lidCloseProtection") private var _lidCloseProtection: Bool = false
 
     /// Lid close protection with pmset control

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,7 @@ let package = Package(
                 "appcast.xml",
                 "dist",
                 "docs",
-                "featured-image.png",
-                "repomix-output.xml"
+                "featured-image.png"
             ],
             sources: [
                 "MacGuardApp.swift",

--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ Comprehensive documentation is available in the `docs/` directory:
 - **[Project Roadmap](docs/project-roadmap.md)** - Completed milestones, known issues, future plans
 - **[Deployment Guide](docs/deployment-guide.md)** - Build instructions, release process, CI/CD
 
+## Built With
+
+This project was developed with the assistance of:
+
+- **[Claude Code](https://claude.ai/code)** - Anthropic's AI-powered coding assistant
+- **[ClaudeKit](https://claudekit.cc/?ref=BPLLTRW2)** - Skills and workflows for Claude Code
+
 ## License
 
 MIT License

--- a/Views/CountdownOverlayView.swift
+++ b/Views/CountdownOverlayView.swift
@@ -67,7 +67,7 @@ struct CountdownOverlayView: View {
 
                         // Progress ring
                         Circle()
-                            .trim(from: 0, to: CGFloat(alarmManager.countdownSeconds) / 3.0)
+                            .trim(from: 0, to: CGFloat(alarmManager.countdownSeconds) / CGFloat(AppSettings.shared.countdownDuration))
                             .stroke(Color.red, style: StrokeStyle(lineWidth: 8, lineCap: .round))
                             .frame(width: 160, height: 160)
                             .rotationEffect(.degrees(-90))

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -218,6 +218,15 @@ struct SettingsView: View {
                 Section {
                     Toggle("Lock screen when armed", isOn: $settings.autoLockOnArm)
 
+                    Picker("Countdown duration", selection: $settings.countdownDuration) {
+                        Text("Immediately").tag(0)
+                        Text("3 seconds").tag(3)
+                        Text("5 seconds").tag(5)
+                        Text("10 seconds").tag(10)
+                        Text("15 seconds").tag(15)
+                        Text("30 seconds").tag(30)
+                    }
+
                     // Lid Close Protection with warning
                     VStack(alignment: .leading, spacing: 6) {
                         Toggle("Lid close alarm (requires admin)", isOn: $settings.lidCloseProtection)
@@ -298,7 +307,7 @@ struct SettingsView: View {
                 // About Section
                 Section {
                     LabeledContent("Version", value: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown")
-                    LabeledContent("macOS", value: "13.0+ (Ventura)")
+                    LabeledContent("macOS", value: macOSVersion)
 
                     // Check for Updates button
                     HStack {
@@ -328,6 +337,11 @@ struct SettingsView: View {
 
     private var appVersion: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+    }
+
+    private var macOSVersion: String {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
     }
 
     private var headerBarGradient: LinearGradient {


### PR DESCRIPTION
## Summary
- Add configurable countdown duration before alarm triggers
- Fix About section to show actual macOS version
- Update README with credits

## Changes

### Countdown Duration Setting
- New picker in Behavior section: Immediately, 3s, 5s, 10s, 15s, 30s
- "Immediately" (0s) skips countdown and triggers alarm instantly
- Progress ring in overlay adapts to selected duration

### About Section
- Show actual macOS version (e.g., 15.2.0) instead of hardcoded "13.0+ (Ventura)"

### README
- Dynamic GitHub badges for version and license
- Added "Built With" section crediting Claude Code and ClaudeKit

## Test plan
- [x] Build succeeds
- [x] Countdown duration picker appears in Settings
- [x] Different durations work correctly
- [x] "Immediately" option triggers alarm without countdown
- [x] macOS version displays correctly