### PR TITLE
feat: add trusted device proximity distance setting

### DIFF
--- a/Managers/BluetoothProximityManager.swift
+++ b/Managers/BluetoothProximityManager.swift
@@ -31,10 +31,13 @@ class BluetoothProximityManager: NSObject, ObservableObject {
     private var connectedPeripheral: CBPeripheral?
     private var rssiReadTimer: Timer?
 
-    // Hysteresis thresholds to prevent oscillation
-    // -70 dBm ≈ 3-5m range, suitable for detecting nearby devices
-    private let rssiPresentThreshold: Int = -70  // Device present when above this
-    private let rssiAwayThreshold: Int = -80     // Device away when below this
+    // Dynamic thresholds from user settings (hysteresis to prevent oscillation)
+    private var rssiPresentThreshold: Int {
+        AppSettings.shared.proximityDistance.presentThreshold
+    }
+    private var rssiAwayThreshold: Int {
+        AppSettings.shared.proximityDistance.awayThreshold
+    }
 
     // UserDefaults key for persistence
     private let trustedDeviceKey = "MacGuard.trustedDevice"
@@ -76,6 +79,8 @@ class BluetoothProximityManager: NSObject, ObservableObject {
     /// Reload trusted device from UserDefaults (called after external update)
     func reloadTrustedDevice() {
         loadTrustedDevice()
+        // Start scanning for the newly loaded device
+        startScanningIfNeeded()
     }
 
     private func loadTrustedDevice() {

--- a/Models/AppSettings.swift
+++ b/Models/AppSettings.swift
@@ -4,6 +4,42 @@
 
 import SwiftUI
 
+/// Proximity distance presets for trusted device detection
+enum ProximityDistance: String, CaseIterable, Identifiable {
+    case near = "Near"      // ~1-2m
+    case medium = "Medium"  // ~3-5m (default)
+    case far = "Far"        // ~7-10m
+
+    var id: String { rawValue }
+
+    /// RSSI threshold for device presence (signal stronger than this = nearby)
+    var presentThreshold: Int {
+        switch self {
+        case .near: return -55
+        case .medium: return -70
+        case .far: return -80
+        }
+    }
+
+    /// RSSI threshold for device away (signal weaker than this = away)
+    var awayThreshold: Int {
+        switch self {
+        case .near: return -65
+        case .medium: return -80
+        case .far: return -90
+        }
+    }
+
+    /// Human-readable description
+    var description: String {
+        switch self {
+        case .near: return "~1-2 meters"
+        case .medium: return "~3-5 meters"
+        case .far: return "~7-10 meters"
+        }
+    }
+}
+
 /// Available alarm sounds
 enum AlarmSound: String, CaseIterable, Identifiable {
     // Bundled sound
@@ -65,6 +101,16 @@ class AppSettings: ObservableObject {
     @AppStorage("customSoundPath") var customSoundPath: String = ""
     @AppStorage("countdownDuration") var countdownDuration: Int = 3
     @AppStorage("lidCloseProtection") private var _lidCloseProtection: Bool = false
+    @AppStorage("proximityDistance") private var proximityDistanceRaw: String = ProximityDistance.medium.rawValue
+
+    /// Proximity distance for trusted device detection
+    var proximityDistance: ProximityDistance {
+        get { ProximityDistance(rawValue: proximityDistanceRaw) ?? .medium }
+        set {
+            proximityDistanceRaw = newValue.rawValue
+            objectWillChange.send()
+        }
+    }
 
     /// Lid close protection with pmset control
     var lidCloseProtection: Bool {

--- a/Models/TrustedDevice.swift
+++ b/Models/TrustedDevice.swift
@@ -30,6 +30,22 @@ struct TrustedDevice: Identifiable, Codable, Hashable {
     /// RSSI threshold for "nearby" detection (-70 dBm ≈ 3-5m)
     static let rssiThreshold: Int = -60
 
+    /// SF Symbol icon based on device name
+    var icon: String {
+        Self.icon(for: name)
+    }
+
+    /// Get SF Symbol icon for a device name
+    static func icon(for name: String) -> String {
+        let lowered = name.lowercased()
+        if lowered.contains("iphone") { return "iphone" }
+        if lowered.contains("watch") { return "applewatch" }
+        if lowered.contains("ipad") { return "ipad" }
+        if lowered.contains("mac") { return "laptopcomputer" }
+        if lowered.contains("airpods") { return "airpodspro" }
+        return "iphone"
+    }
+
     // MARK: - Initialization
 
     init(id: UUID, name: String) {

--- a/Views/DeviceScannerView.swift
+++ b/Views/DeviceScannerView.swift
@@ -40,7 +40,7 @@ class DeviceScannerWindowController: NSObject, NSWindowDelegate {
         let view = DeviceScannerContainerView(viewModel: viewModel, onDismiss: { [weak self] in
             self?.viewModel.stopScanning()
             self?.window?.orderOut(nil)
-            NSApp.setActivationPolicy(.accessory)
+            // Don't change activation policy - let Settings window handle it
         })
         hostingController = NSHostingController(rootView: view)
 
@@ -61,7 +61,7 @@ class DeviceScannerWindowController: NSObject, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         viewModel.stopScanning()
-        NSApp.setActivationPolicy(.accessory)
+        // Don't change activation policy - let Settings window handle it
     }
 }
 
@@ -241,7 +241,7 @@ struct DeviceScannerContainerView: View {
                                     .fill(.blue.opacity(0.1))
                                     .frame(width: 40, height: 40)
 
-                                Image(systemName: deviceIcon(for: device.name))
+                                Image(systemName: TrustedDevice.icon(for: device.name))
                                     .font(.system(size: 18))
                                     .foregroundStyle(.blue)
                             }
@@ -300,16 +300,6 @@ struct DeviceScannerContainerView: View {
             .padding()
         }
         .frame(width: 350, height: 400)
-    }
-
-    private func deviceIcon(for name: String) -> String {
-        let lowered = name.lowercased()
-        if lowered.contains("iphone") { return "iphone" }
-        if lowered.contains("watch") { return "applewatch" }
-        if lowered.contains("ipad") { return "ipad" }
-        if lowered.contains("mac") { return "laptopcomputer" }
-        if lowered.contains("airpods") { return "airpodspro" }
-        return "wave.3.right"
     }
 
     private func signalStrengthText(for rssi: Int) -> String {

--- a/Views/MenuBarView.swift
+++ b/Views/MenuBarView.swift
@@ -107,7 +107,7 @@ struct MenuBarView: View {
                 Circle()
                     .fill(device.isNearby ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .frame(width: 32, height: 32)
-                Image(systemName: deviceIcon(for: device.name))
+                Image(systemName: device.icon)
                     .font(.system(size: 14))
                     .foregroundStyle(device.isNearby ? .green : .secondary)
             }
@@ -279,17 +279,6 @@ struct MenuBarView: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private func deviceIcon(for name: String) -> String {
-        let lowered = name.lowercased()
-        if lowered.contains("iphone") { return "iphone" }
-        if lowered.contains("watch") { return "applewatch" }
-        if lowered.contains("ipad") { return "ipad" }
-        if lowered.contains("airpods") { return "airpodspro" }
-        if lowered.contains("mac") { return "laptopcomputer" }
-        return "wave.3.right"
-    }
 }
 
 #Preview {

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -126,7 +126,7 @@ struct SettingsView: View {
                 Section {
                     if let device = alarmManager.bluetoothManager.trustedDevice {
                         HStack(spacing: 12) {
-                            Image(systemName: deviceIcon(for: device.name))
+                            Image(systemName: device.icon)
                                 .font(.title2)
                                 .foregroundColor(.blue)
                                 .frame(width: 32)
@@ -151,6 +151,13 @@ struct SettingsView: View {
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                         }
+
+                        Picker("Detection Distance", selection: $settings.proximityDistance) {
+                            ForEach(ProximityDistance.allCases) { distance in
+                                Text("\(distance.rawValue) (\(distance.description))").tag(distance)
+                            }
+                        }
+                        .pickerStyle(.menu)
                     } else {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("No trusted device configured")
@@ -372,15 +379,6 @@ struct SettingsView: View {
             return nil
         }
         return image
-    }
-
-    private func deviceIcon(for name: String) -> String {
-        let lowered = name.lowercased()
-        if lowered.contains("iphone") { return "iphone" }
-        if lowered.contains("watch") { return "applewatch" }
-        if lowered.contains("ipad") { return "ipad" }
-        if lowered.contains("airpods") { return "airpodspro" }
-        return "wave.3.right"
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Add configurable proximity detection distance (Near/Medium/Far presets)
- Fix scanning not starting when trusted device first added
- Fix settings window closing after device selection
- Consolidate duplicate deviceIcon function

## Changes
| File | Change |
|------|--------|
| `Models/AppSettings.swift` | Add `ProximityDistance` enum + setting |
| `Models/TrustedDevice.swift` | Add shared `icon` property |
| `Managers/BluetoothProximityManager.swift` | Use dynamic thresholds, start scanning on reload |
| `Views/SettingsView.swift` | Add Detection Distance picker |
| `Views/DeviceScannerView.swift` | Remove duplicate icon func, fix window behavior |
| `Views/MenuBarView.swift` | Use shared icon property |

## Test plan
- [ ] Verify Distance picker appears when trusted device configured
- [ ] Test Near/Medium/Far presets affect detection range
- [ ] Verify setting persists across restarts
- [ ] Confirm settings window stays open after device selection