### PR TITLE
fix: use dynamic threshold for trusted device proximity check

### DIFF
--- a/Models/TrustedDevice.swift
+++ b/Models/TrustedDevice.swift
@@ -21,14 +21,11 @@ struct TrustedDevice: Identifiable, Codable, Hashable {
     // MARK: - Computed Properties
 
     /// Whether device is considered nearby based on RSSI threshold
-    /// -50 dBm ≈ 1m distance (validated setting)
+    /// Uses dynamic threshold from AppSettings to match detection logic
     var isNearby: Bool {
         guard let rssi = lastRSSI else { return false }
-        return rssi > TrustedDevice.rssiThreshold
+        return rssi > AppSettings.shared.proximityDistance.awayThreshold
     }
-
-    /// RSSI threshold for "nearby" detection (-70 dBm ≈ 3-5m)
-    static let rssiThreshold: Int = -60
 
     /// SF Symbol icon based on device name
     var icon: String {


### PR DESCRIPTION
## Summary
- Fixed threshold mismatch where `TrustedDevice.isNearby` used hardcoded `-60` threshold while `BluetoothProximityManager.handleRSSI()` used dynamic `AppSettings` thresholds
- After owner authorization (disarm), device wasn't recognized as nearby even though it was within range

## Root Cause
Two different threshold systems were used:
1. `BluetoothProximityManager`: Dynamic thresholds from `AppSettings.proximityDistance`
2. `TrustedDevice.isNearby`: Hardcoded static `-60` threshold

## Fix
`TrustedDevice.isNearby` now uses `AppSettings.shared.proximityDistance.awayThreshold` to match the hysteresis logic.

## Test plan
- [x] Build succeeds
- [ ] Add trusted device, move away until auto-arm triggers
- [ ] Authenticate to disarm, verify device recognized as nearby