### PR TITLE
fix: track proximity state explicitly instead of recomputing from RSSI

### DIFF
--- a/Managers/BluetoothProximityManager.swift
+++ b/Managers/BluetoothProximityManager.swift
@@ -24,6 +24,7 @@ class BluetoothProximityManager: NSObject, ObservableObject {
     @Published var isBluetoothEnabled = false
     @Published private(set) var trustedDevice: TrustedDevice?
     @Published var isScanning = false
+    @Published private(set) var isDeviceNearby = false
 
     // MARK: - Private Properties
 
@@ -141,6 +142,7 @@ class BluetoothProximityManager: NSObject, ObservableObject {
         }
 
         isScanning = false
+        isDeviceNearby = false
         print("[Bluetooth] Stopped scanning")
     }
 
@@ -163,9 +165,11 @@ class BluetoothProximityManager: NSObject, ObservableObject {
         let isNearby = rssi > rssiPresentThreshold
 
         if !wasNearby && isNearby {
+            isDeviceNearby = true
             print("[Bluetooth] Trusted device nearby (RSSI: \(rssi))")
             delegate?.trustedDeviceNearby(device)
         } else if wasNearby && rssi < rssiAwayThreshold {
+            isDeviceNearby = false
             print("[Bluetooth] Trusted device away (RSSI: \(rssi))")
             delegate?.trustedDeviceAway(device)
         }
@@ -173,7 +177,7 @@ class BluetoothProximityManager: NSObject, ObservableObject {
 
     /// Check if trusted device is currently nearby
     func isTrustedDeviceNearby() -> Bool {
-        trustedDevice?.isNearby ?? false
+        isDeviceNearby
     }
 }
 

--- a/Models/TrustedDevice.swift
+++ b/Models/TrustedDevice.swift
@@ -20,13 +20,6 @@ struct TrustedDevice: Identifiable, Codable, Hashable {
 
     // MARK: - Computed Properties
 
-    /// Whether device is considered nearby based on RSSI threshold
-    /// Uses dynamic threshold from AppSettings to match detection logic
-    var isNearby: Bool {
-        guard let rssi = lastRSSI else { return false }
-        return rssi > AppSettings.shared.proximityDistance.awayThreshold
-    }
-
     /// SF Symbol icon based on device name
     var icon: String {
         Self.icon(for: name)

--- a/Views/MenuBarView.swift
+++ b/Views/MenuBarView.swift
@@ -102,27 +102,28 @@ struct MenuBarView: View {
     }
 
     private func deviceSection(_ device: TrustedDevice) -> some View {
-        HStack(spacing: 10) {
+        let isNearby = alarmManager.bluetoothManager.isDeviceNearby
+        return HStack(spacing: 10) {
             ZStack {
                 Circle()
-                    .fill(device.isNearby ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
+                    .fill(isNearby ? Color.green.opacity(0.15) : Color.secondary.opacity(0.1))
                     .frame(width: 32, height: 32)
                 Image(systemName: device.icon)
                     .font(.system(size: 14))
-                    .foregroundStyle(device.isNearby ? .green : .secondary)
+                    .foregroundStyle(isNearby ? .green : .secondary)
             }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(device.name)
                     .font(.subheadline.weight(.medium))
-                Text(device.isNearby ? "Nearby" : "Not detected")
+                Text(isNearby ? "Nearby" : "Not detected")
                     .font(.caption)
-                    .foregroundStyle(device.isNearby ? .green : .secondary)
+                    .foregroundStyle(isNearby ? .green : .secondary)
             }
 
             Spacer()
 
-            if device.isNearby {
+            if isNearby {
                 Circle()
                     .fill(.green)
                     .frame(width: 8, height: 8)

--- a/Views/SettingsView.swift
+++ b/Views/SettingsView.swift
@@ -140,7 +140,7 @@ struct SettingsView: View {
                                 }
                             }
                             Spacer()
-                            if device.isNearby {
+                            if alarmManager.bluetoothManager.isDeviceNearby {
                                 Label("Nearby", systemImage: "checkmark.circle.fill")
                                     .font(.caption)
                                     .foregroundColor(.green)


### PR DESCRIPTION
## Summary
- Fixed auto-disarm not working when trusted device brought nearby during alarm
- Root cause: `isTrustedDeviceNearby()` was recomputing from raw RSSI with single threshold, inconsistent with hysteresis-based callback logic

## Changes
- Add `isDeviceNearby` published state to `BluetoothProximityManager`
- State updated in sync with `trustedDeviceNearby`/`trustedDeviceAway` callbacks
- `isTrustedDeviceNearby()` now returns tracked state
- UI updated to use `bluetoothManager.isDeviceNearby`
- Removed redundant `TrustedDevice.isNearby` computed property

## Test plan
- [x] Build succeeds
- [ ] Arm alarm, trigger via input, bring trusted device nearby → auto-disarm
- [ ] Verify UI shows correct "Nearby" status in menu bar and settings