### PR TITLE
fix: improve Bluetooth proximity detection reliability

### DIFF
--- a/Models/TrustedDevice.swift
+++ b/Models/TrustedDevice.swift
@@ -12,11 +12,16 @@ struct TrustedDevice: Identifiable, Codable, Hashable {
     /// User-friendly device name
     var name: String
 
-    /// Last measured RSSI value (signal strength)
+    /// Last measured RSSI value (signal strength) - runtime only, not persisted
     var lastRSSI: Int?
 
-    /// Last time device was seen
+    /// Last time device was seen - runtime only, not persisted
     var lastSeen: Date?
+
+    // Only persist id and name
+    enum CodingKeys: String, CodingKey {
+        case id, name
+    }
 
     // MARK: - Computed Properties
 


### PR DESCRIPTION
## Summary
- Fixed auto-disarm not triggering when device returns during alarm
- Root cause: RSSI fluctuations in hysteresis dead zone prevented state transition

## Changes
- Reset `lastRSSI` on scan start to ensure first reading triggers state evaluation
- Exclude `lastRSSI`/`lastSeen` from persistence (runtime state only)
- Improved hysteresis logic: trigger nearby callback when current state is false but RSSI shows nearby, not just on clean RSSI transitions

## Test plan
- [x] Build succeeds
- [x] Manual test: arm → trigger → bring device nearby → auto-disarm ✓