### PR TITLE
feat: auto-disarm when trusted device returns while armed

### DIFF
--- a/Managers/AlarmStateManager.swift
+++ b/Managers/AlarmStateManager.swift
@@ -177,6 +177,9 @@ class AlarmStateManager: ObservableObject {
 
         state = .idle
         print("[MacGuard] Disarmed")
+
+        // Restart background scanning for UI display
+        bluetoothManager.startScanning()
     }
 
     /// Attempt to disarm with biometric authentication
@@ -370,8 +373,8 @@ extension AlarmStateManager: BluetoothProximityDelegate {
             // Cancel pending auto-arm
             self.cancelAutoArmTimer()
 
-            // Auto-disarm if in triggered or alarming state
-            if self.state == .triggered || self.state == .alarming {
+            // Auto-disarm if armed, triggered, or alarming
+            if self.state == .armed || self.state == .triggered || self.state == .alarming {
                 print("[MacGuard] Trusted device detected - auto-disarming")
                 self.disarm()
             }


### PR DESCRIPTION
## Summary
- Auto-disarm when trusted device returns while in armed state (not just triggered/alarming)
- Restart background scanning after disarm for UI RSSI display

## Rationale
- While disarmed, app doesn't monitor input → saves memory, power
- More convenient UX: trusted device nearby = owner is back

## Test plan
- [x] Build succeeds
- [x] Manual test: auto-arm → device returns while armed → auto-disarm ✓
- [x] RSSI continues updating after disarm ✓