### PR TITLE
feat: add liquid glass UI theme foundation (Phase 1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,8 @@ let package = Package(
                 "Managers",
                 "Views",
                 "Models",
-                "Utilities"
+                "Utilities",
+                "Theme"
             ],
             resources: [
                 .copy("Resources")

--- a/Theme/GlassButtonStyles.swift
+++ b/Theme/GlassButtonStyles.swift
@@ -1,0 +1,248 @@
+// GlassButtonStyles.swift
+// MacGuard - Liquid Glass UI Theme
+// Created: 2025-12-21
+
+import SwiftUI
+
+// MARK: - Primary Button Style (Capsule, Prominent)
+
+struct GlassPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .foregroundStyle(.primary)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
+            .background {
+                Capsule()
+                    .fill(.clear)
+                    .background(
+                        VisualEffectView(
+                            material: .hudWindow,
+                            blendingMode: .withinWindow,
+                            isEmphasized: configuration.isPressed
+                        )
+                    )
+                    .clipShape(Capsule())
+            }
+            .glassCapsuleBorder(prominent: true)
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .opacity(isEnabled ? 1.0 : 0.5)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Secondary Button Style (Rounded Rect, Subtle)
+
+struct GlassSecondaryButtonStyle: ButtonStyle {
+    var cornerRadius: CGFloat = Theme.CornerRadius.sm
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.subheadline)
+            .foregroundStyle(.primary)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.xs + 2)
+            .background {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(.clear)
+                    .background(
+                        VisualEffectView(
+                            material: .hudWindow,
+                            blendingMode: .withinWindow,
+                            isEmphasized: configuration.isPressed
+                        )
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            }
+            .glassBorder(cornerRadius: cornerRadius)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Menu Row Button Style
+
+struct GlassMenuRowButtonStyle: ButtonStyle {
+    @State private var isHovered = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                if isHovered || configuration.isPressed {
+                    RoundedRectangle(cornerRadius: Theme.CornerRadius.sm)
+                        .fill(.clear)
+                        .background(
+                            VisualEffectView(
+                                material: .selection,
+                                blendingMode: .withinWindow,
+                                isEmphasized: configuration.isPressed
+                            )
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.sm))
+                }
+            }
+            .contentShape(Rectangle())
+            .onHover { isHovered = $0 }
+    }
+}
+
+// MARK: - Pill Button Style (Compact Capsule)
+
+struct GlassPillButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.caption.weight(.medium))
+            .foregroundStyle(.primary)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.xs)
+            .background {
+                Capsule()
+                    .fill(.clear)
+                    .background(
+                        VisualEffectView(
+                            material: .hudWindow,
+                            blendingMode: .withinWindow,
+                            isEmphasized: configuration.isPressed
+                        )
+                    )
+                    .clipShape(Capsule())
+            }
+            .glassCapsuleBorder()
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Icon Button Style (Circle)
+
+struct GlassIconButtonStyle: ButtonStyle {
+    var size: CGFloat = 32
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: size * 0.5))
+            .foregroundStyle(.primary)
+            .frame(width: size, height: size)
+            .background {
+                Circle()
+                    .fill(.clear)
+                    .background(
+                        VisualEffectView(
+                            material: .selection,
+                            blendingMode: .withinWindow,
+                            isEmphasized: configuration.isPressed
+                        )
+                    )
+                    .clipShape(Circle())
+            }
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.15), location: 0.0),
+                                .init(color: .clear, location: 0.5),
+                                .init(color: .black.opacity(0.08), location: 1.0)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: 0.5
+                    )
+            )
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - State-Colored Primary Button
+
+struct GlassStateButtonStyle: ButtonStyle {
+    let state: AlarmState
+
+    var stateColor: Color {
+        switch state {
+        case .idle: return Theme.StateColor.idle
+        case .armed: return Theme.StateColor.armed
+        case .triggered: return Theme.StateColor.triggered
+        case .alarming: return Theme.StateColor.alarming
+        }
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .foregroundStyle(.white)
+            .padding(.horizontal, Theme.Spacing.xl)
+            .padding(.vertical, Theme.Spacing.md)
+            .background {
+                ZStack {
+                    Capsule()
+                        .fill(stateColor)
+
+                    // Glass overlay
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                stops: [
+                                    .init(color: .white.opacity(0.25), location: 0.0),
+                                    .init(color: .clear, location: 0.5),
+                                    .init(color: .black.opacity(0.15), location: 1.0)
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                }
+            }
+            .glassCapsuleBorder(prominent: true)
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .shadow(color: stateColor.opacity(0.4), radius: 8, y: 4)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}
+
+// MARK: - Bordered Prominent Glass Button (replacement for system .borderedProminent)
+
+struct GlassBorderedProminentButtonStyle: ButtonStyle {
+    var tint: Color = .accentColor
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(.white)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background {
+                ZStack {
+                    Capsule()
+                        .fill(tint)
+
+                    // Glass overlay
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                stops: [
+                                    .init(color: .white.opacity(0.20), location: 0.0),
+                                    .init(color: .clear, location: 0.5),
+                                    .init(color: .black.opacity(0.10), location: 1.0)
+                                ],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                }
+            }
+            .glassCapsuleBorder(prominent: true)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .opacity(isEnabled ? 1.0 : 0.5)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/Theme/GlassComponents.swift
+++ b/Theme/GlassComponents.swift
@@ -1,0 +1,228 @@
+// GlassComponents.swift
+// MacGuard - Liquid Glass UI Theme
+// Created: 2025-12-21
+
+import SwiftUI
+
+// MARK: - Glass Background (Regular Variant)
+
+/// Regular liquid glass background for navigation, controls, menus
+/// High blur + luminosity adjustment
+struct GlassBackground: View {
+    var material: NSVisualEffectView.Material = .menu
+    var cornerRadius: CGFloat = Theme.CornerRadius.lg
+    var showBorder: Bool = true
+
+    var body: some View {
+        ZStack {
+            // Base material
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(.clear)
+                .background(
+                    VisualEffectView(
+                        material: material,
+                        blendingMode: .withinWindow,
+                        isEmphasized: true
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+
+            // Depth gradient overlay
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.08), location: 0.0),
+                            .init(color: .clear, location: 0.5),
+                            .init(color: .black.opacity(0.05), location: 1.0)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .allowsHitTesting(false)
+        }
+        .overlay {
+            if showBorder {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.20), location: 0.0),
+                                .init(color: .white.opacity(0.08), location: 0.3),
+                                .init(color: .clear, location: 0.5),
+                                .init(color: .black.opacity(0.08), location: 1.0)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: 0.5
+                    )
+            }
+        }
+    }
+}
+
+// MARK: - Clear Glass Background (Over Media/Content)
+
+/// Clear liquid glass for media overlays, immersive content
+/// Minimal blur, highly translucent
+struct ClearGlassBackground: View {
+    var overBrightContent: Bool = false
+    var cornerRadius: CGFloat = Theme.CornerRadius.lg
+    var showBorder: Bool = true
+
+    var body: some View {
+        ZStack {
+            // Dimming layer for bright backgrounds
+            if overBrightContent {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color.black.opacity(0.35))
+            }
+
+            // Lighter material
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(.clear)
+                .background(
+                    VisualEffectView(
+                        material: .sheet,
+                        blendingMode: .withinWindow,
+                        isEmphasized: false
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+
+            // Minimal depth gradient
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.06), location: 0.0),
+                            .init(color: .black.opacity(0.04), location: 1.0)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .allowsHitTesting(false)
+        }
+        .overlay {
+            if showBorder {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.15), location: 0.0),
+                                .init(color: .clear, location: 0.5),
+                                .init(color: .black.opacity(0.06), location: 1.0)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: 0.5
+                    )
+            }
+        }
+    }
+}
+
+// MARK: - Glass Section Container
+
+/// Container for settings sections with glass background
+struct GlassSection<Content: View>: View {
+    let title: String?
+    @ViewBuilder let content: () -> Content
+
+    init(title: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            if let title {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+            }
+
+            content()
+        }
+        .padding(Theme.Spacing.lg)
+        .background {
+            GlassBackground(
+                material: .headerView,
+                cornerRadius: Theme.CornerRadius.lg
+            )
+        }
+    }
+}
+
+// MARK: - Glass Card
+
+/// Prominent glass card for modals, overlays
+struct GlassCard<Content: View>: View {
+    var cornerRadius: CGFloat = Theme.CornerRadius.xxxl
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .background {
+                GlassBackground(
+                    material: .hudWindow,
+                    cornerRadius: cornerRadius
+                )
+                .modalShadow()
+            }
+    }
+}
+
+// MARK: - Full Screen Glass Background
+
+/// Full-screen glass overlay for countdown/alarm states
+struct FullScreenGlass: View {
+    var body: some View {
+        VisualEffectView(
+            material: .fullScreenUI,
+            blendingMode: .withinWindow,
+            isEmphasized: true
+        )
+        .ignoresSafeArea()
+    }
+}
+
+// MARK: - Glass Icon Circle
+
+/// Circular glass background for icons
+struct GlassIconCircle: View {
+    var size: CGFloat = 32
+    var material: NSVisualEffectView.Material = .selection
+
+    var body: some View {
+        Circle()
+            .fill(.clear)
+            .background(
+                VisualEffectView(
+                    material: material,
+                    blendingMode: .withinWindow
+                )
+            )
+            .clipShape(Circle())
+            .frame(width: size, height: size)
+            .overlay(
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.15), location: 0.0),
+                                .init(color: .clear, location: 0.5),
+                                .init(color: .black.opacity(0.08), location: 1.0)
+                            ],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        ),
+                        lineWidth: 0.5
+                    )
+            )
+    }
+}

--- a/Theme/GlassModifiers.swift
+++ b/Theme/GlassModifiers.swift
@@ -1,0 +1,111 @@
+// GlassModifiers.swift
+// MacGuard - Liquid Glass UI Theme
+// Created: 2025-12-21
+
+import SwiftUI
+
+// MARK: - Glass Border Modifier
+
+struct GlassBorder: ViewModifier {
+    let cornerRadius: CGFloat
+    var prominent: Bool = false
+
+    func body(content: Content) -> some View {
+        content.overlay(
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .strokeBorder(borderGradient, lineWidth: 0.5)
+        )
+    }
+
+    private var borderGradient: LinearGradient {
+        if prominent {
+            return LinearGradient(
+                stops: [
+                    .init(color: .white.opacity(0.25), location: 0.0),
+                    .init(color: .white.opacity(0.12), location: 0.2),
+                    .init(color: .clear, location: 0.4),
+                    .init(color: .black.opacity(0.12), location: 1.0)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        } else {
+            return LinearGradient(
+                stops: [
+                    .init(color: .white.opacity(0.20), location: 0.0),
+                    .init(color: .white.opacity(0.08), location: 0.3),
+                    .init(color: .clear, location: 0.5),
+                    .init(color: .black.opacity(0.08), location: 1.0)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+}
+
+extension View {
+    /// Apply glass border with gradient highlight
+    func glassBorder(cornerRadius: CGFloat = 8, prominent: Bool = false) -> some View {
+        modifier(GlassBorder(cornerRadius: cornerRadius, prominent: prominent))
+    }
+}
+
+// MARK: - Glass Capsule Border (for buttons)
+
+struct GlassCapsuleBorder: ViewModifier {
+    var prominent: Bool = false
+
+    func body(content: Content) -> some View {
+        content.overlay(
+            Capsule()
+                .strokeBorder(borderGradient, lineWidth: 0.5)
+        )
+    }
+
+    private var borderGradient: LinearGradient {
+        LinearGradient(
+            stops: [
+                .init(color: .white.opacity(prominent ? 0.25 : 0.20), location: 0.0),
+                .init(color: .white.opacity(prominent ? 0.12 : 0.08), location: 0.3),
+                .init(color: .clear, location: 0.5),
+                .init(color: .black.opacity(prominent ? 0.12 : 0.08), location: 1.0)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+}
+
+extension View {
+    func glassCapsuleBorder(prominent: Bool = false) -> some View {
+        modifier(GlassCapsuleBorder(prominent: prominent))
+    }
+}
+
+// MARK: - Glass Background Modifier
+
+extension View {
+    /// Apply glass background with material
+    func glassBackground(
+        material: NSVisualEffectView.Material = .menu,
+        cornerRadius: CGFloat = Theme.CornerRadius.lg
+    ) -> some View {
+        self.background {
+            GlassBackground(material: material, cornerRadius: cornerRadius)
+        }
+    }
+
+    /// Apply clear glass background (for media overlays)
+    func clearGlassBackground(
+        overBrightContent: Bool = false,
+        cornerRadius: CGFloat = Theme.CornerRadius.lg
+    ) -> some View {
+        self.background {
+            ClearGlassBackground(
+                overBrightContent: overBrightContent,
+                cornerRadius: cornerRadius
+            )
+        }
+    }
+}

--- a/Theme/ThemeConstants.swift
+++ b/Theme/ThemeConstants.swift
@@ -1,0 +1,110 @@
+// ThemeConstants.swift
+// MacGuard - Liquid Glass UI Theme
+// Created: 2025-12-21
+
+import SwiftUI
+
+// MARK: - Theme Namespace
+
+enum Theme {
+    // MARK: - State Colors (semantic)
+
+    enum StateColor {
+        static let idle = Color.gray
+        static let armed = Color.green
+        static let triggered = Color.orange
+        static let alarming = Color.red
+    }
+
+    // MARK: - Accent Colors
+
+    enum Accent {
+        static let primary = Color.blue
+        static let success = Color.green
+        static let warning = Color.orange
+        static let danger = Color.red
+        static let info = Color.blue
+    }
+
+    // MARK: - Background Opacities
+
+    enum Opacity {
+        static let surfaceSubtle: Double = 0.06
+        static let surfaceHover: Double = 0.08
+        static let surfaceActive: Double = 0.15
+        static let overlayLight: Double = 0.35
+        static let overlayMedium: Double = 0.50
+        static let overlayHeavy: Double = 0.85
+        static let overlayFull: Double = 0.95
+    }
+
+    // MARK: - Corner Radius
+
+    enum CornerRadius {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 6
+        static let md: CGFloat = 8
+        static let lg: CGFloat = 12
+        static let xl: CGFloat = 16
+        static let xxl: CGFloat = 20
+        static let xxxl: CGFloat = 24
+    }
+
+    // MARK: - Spacing
+
+    enum Spacing {
+        static let xs: CGFloat = 4
+        static let sm: CGFloat = 8
+        static let md: CGFloat = 12
+        static let lg: CGFloat = 16
+        static let xl: CGFloat = 20
+        static let xxl: CGFloat = 24
+        static let xxxl: CGFloat = 32
+    }
+}
+
+// MARK: - Shadow Modifiers
+
+struct DropdownShadow: ViewModifier {
+    func body(content: Content) -> some View {
+        content.shadow(color: .black.opacity(0.25), radius: 20, y: 8)
+    }
+}
+
+struct ModalShadow: ViewModifier {
+    func body(content: Content) -> some View {
+        content.shadow(color: .black.opacity(0.40), radius: 40, y: 20)
+    }
+}
+
+struct IntenseShadow: ViewModifier {
+    func body(content: Content) -> some View {
+        content.shadow(color: .black.opacity(0.50), radius: 50, y: 25)
+    }
+}
+
+struct ButtonShadow: ViewModifier {
+    let color: Color
+
+    func body(content: Content) -> some View {
+        content.shadow(color: color.opacity(0.40), radius: 8, y: 4)
+    }
+}
+
+extension View {
+    func dropdownShadow() -> some View {
+        modifier(DropdownShadow())
+    }
+
+    func modalShadow() -> some View {
+        modifier(ModalShadow())
+    }
+
+    func intenseShadow() -> some View {
+        modifier(IntenseShadow())
+    }
+
+    func buttonShadow(color: Color = .black) -> some View {
+        modifier(ButtonShadow(color: color))
+    }
+}

--- a/Theme/VisualEffectView.swift
+++ b/Theme/VisualEffectView.swift
@@ -1,0 +1,63 @@
+// VisualEffectView.swift
+// MacGuard - Liquid Glass UI Theme
+// Created: 2025-12-21
+
+import SwiftUI
+import AppKit
+
+/// NSVisualEffectView wrapper for SwiftUI
+/// Provides blur materials for liquid glass backporting to macOS 13+
+struct VisualEffectView: NSViewRepresentable {
+    let material: NSVisualEffectView.Material
+    let blendingMode: NSVisualEffectView.BlendingMode
+    var isEmphasized: Bool = false
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        view.isEmphasized = isEmphasized
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
+        nsView.isEmphasized = isEmphasized
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension VisualEffectView {
+    /// Menu dropdown material
+    static var menu: VisualEffectView {
+        VisualEffectView(material: .menu, blendingMode: .withinWindow, isEmphasized: true)
+    }
+
+    /// Selection highlight material
+    static var selection: VisualEffectView {
+        VisualEffectView(material: .selection, blendingMode: .withinWindow, isEmphasized: true)
+    }
+
+    /// Header/section material
+    static var header: VisualEffectView {
+        VisualEffectView(material: .headerView, blendingMode: .withinWindow)
+    }
+
+    /// HUD window material (dark, prominent)
+    static var hud: VisualEffectView {
+        VisualEffectView(material: .hudWindow, blendingMode: .withinWindow, isEmphasized: true)
+    }
+
+    /// Full-screen UI material (immersive)
+    static var fullScreen: VisualEffectView {
+        VisualEffectView(material: .fullScreenUI, blendingMode: .withinWindow, isEmphasized: true)
+    }
+
+    /// Sidebar material
+    static var sidebar: VisualEffectView {
+        VisualEffectView(material: .sidebar, blendingMode: .behindWindow)
+    }
+}


### PR DESCRIPTION
## Summary
- Create Theme/ directory with reusable glass effect components
- VisualEffectView: NSViewRepresentable wrapper for NSVisualEffectView blur materials
- ThemeConstants: Centralized colors (state colors), spacing scales, corner radius, shadow modifiers
- GlassModifiers: glassBorder(), glassCapsuleBorder() ViewModifiers with gradient highlights
- GlassComponents: GlassBackground, ClearGlassBackground, GlassCard, GlassSection, FullScreenGlass
- GlassButtonStyles: Primary, Secondary, MenuRow, Pill, Icon, State button styles

## Details
Part 1/7 of liquid glass UI implementation backporting macOS 26 Tahoe aesthetics to macOS 13+.

### New Files
| File | Purpose |
|------|---------|
| Theme/VisualEffectView.swift | NSViewRepresentable wrapper for NSVisualEffectView |
| Theme/ThemeConstants.swift | Colors, spacing, corner radius, shadows |
| Theme/GlassModifiers.swift | glassBorder(), glassCapsuleBorder() modifiers |
| Theme/GlassComponents.swift | Reusable glass background views |
| Theme/GlassButtonStyles.swift | ButtonStyle implementations |

## Test Plan
- [x] Project compiles successfully with `swift build`
- [ ] Visual verification of glass effects in subsequent phases