### PR TITLE
fix: prevent Settings window from closing when disarming

### DIFF
--- a/Views/CountdownWindowController.swift
+++ b/Views/CountdownWindowController.swift
@@ -43,7 +43,6 @@ class CountdownWindowController {
     /// Hide the overlay (does not destroy window)
     func hide() {
         window?.orderOut(nil)
-        NSApp.setActivationPolicy(.accessory)
         print("[Overlay] Countdown overlay hidden")
     }
 


### PR DESCRIPTION
## Summary
- Remove `setActivationPolicy(.accessory)` from `CountdownWindowController.hide()` which was causing all windows (including Settings) to close when the countdown overlay was hidden during disarm

## Test plan
- [x] Open Settings window
- [x] Arm MacGuard via header quick action button
- [x] Disarm via header quick action button
- [x] Verify Settings window stays open